### PR TITLE
skip scan composer.lock in vendor dir

### DIFF
--- a/analyzer/library/composer/composer.go
+++ b/analyzer/library/composer/composer.go
@@ -3,6 +3,7 @@ package composer
 import (
 	"bytes"
 	"path/filepath"
+	"strings"
 
 	"github.com/aquasecurity/fanal/analyzer"
 	"github.com/aquasecurity/fanal/extractor"
@@ -25,6 +26,11 @@ func (a composerLibraryAnalyzer) Analyze(fileMap extractor.FileMap) (map[analyze
 	for filename, content := range fileMap {
 		basename := filepath.Base(filename)
 		if !utils.StringInSlice(basename, requiredFiles) {
+			continue
+		}
+
+		// skip analyze files which in dependency folder
+		if utils.StringInSlice(utils.COMPOSER_DEP_DIR, strings.Split(filename, utils.PathSeparator)) {
 			continue
 		}
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -7,8 +7,9 @@ import (
 )
 
 var (
-	NODE_DEP_DIR  = "node_modules"
-	PathSeparator = fmt.Sprintf("%c", os.PathSeparator)
+	NODE_DEP_DIR     = "node_modules"
+	COMPOSER_DEP_DIR = "vendor"
+	PathSeparator    = fmt.Sprintf("%c", os.PathSeparator)
 )
 
 func CacheDir() string {


### PR DESCRIPTION
https://github.com/aquasecurity/fanal/issues/33
https://github.com/aquasecurity/trivy/issues/147

before
```
data/vendor/simplesamlphp/simplesamlphp/modules/mfa/composer.lock: 38
root/.composer/composer.lock: 1
data/vendor/silinternational/psr3-adapters/composer.lock: 2
data/vendor/silinternational/ssp-utilities/composer.lock: 6
data/vendor/simplesamlphp/simplesamlphp/composer.lock: 24
data/vendor/simplesamlphp/simplesamlphp/modules/sildisco/composer.lock: 36
root/.composer/vendor/fxp/composer-asset-plugin/composer.lock: 0
data/vendor/simplesamlphp/simplesamlphp/modules/profilereview/composer.lock: 29
data/vendor/simplesamlphp/simplesamlphp/modules/silauth/composer.lock: 57
data/vendor/simplesamlphp/simplesamlphp/modules/sildisco/development/browser_test/composer.lock: 0
data/composer.lock: 68
data/vendor/simplesamlphp/simplesamlphp/modules/expirychecker/composer.lock: 27
```

after
```
root/.composer/composer.lock: 1
data/composer.lock: 68
```

`root/.composer` is irregular pattern.