### PR TITLE
Bug fix: wrap nil err

### DIFF
--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -164,8 +164,10 @@ func GetPackages(filesMap extractor.FileMap) ([]Package, error) {
 		// Differentiate between a package manager not being found and another error
 		if err != nil && err == ErrNoPkgsDetected {
 			continue
+		} else if err != nil {
+			return nil, xerrors.Errorf("failed to analyze packages: %w", err)
 		}
-		return pkgs, xerrors.Errorf("failed to analyze packages: %w", err)
+		return pkgs, nil
 	}
 	return nil, ErrPkgAnalysis
 }


### PR DESCRIPTION
Fix a bug from #35. Even if err is nil, it is wrapped.