### PR TITLE
Fix wrong break

### DIFF
--- a/analyzer/pkg/rpm/rpm.go
+++ b/analyzer/pkg/rpm/rpm.go
@@ -33,7 +33,10 @@ func (a rpmPkgAnalyzer) Analyze(fileMap extractor.FileMap) (pkgs []analyzer.Pack
 	if !detected {
 		return nil, analyzer.ErrNoPkgsDetected
 	}
-	return pkgs, xerrors.Errorf("failed to parse the pkg info: %w", err)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to parse the pkg info: %w", err)
+	}
+	return pkgs, nil
 }
 
 func (a rpmPkgAnalyzer) parsePkgInfo(packageBytes []byte) (pkgs []analyzer.Package, err error) {

--- a/analyzer/pkg/rpmcmd/rpm.go
+++ b/analyzer/pkg/rpmcmd/rpm.go
@@ -36,7 +36,10 @@ func (a rpmCmdPkgAnalyzer) Analyze(fileMap extractor.FileMap) (pkgs []analyzer.P
 	if !detected {
 		return pkgs, analyzer.ErrNoPkgsDetected
 	}
-	return pkgs, xerrors.Errorf("failed to parse the pkg info: %w", err)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to parse the pkg info: %w", err)
+	}
+	return pkgs, nil
 }
 
 func (a rpmCmdPkgAnalyzer) parsePkgInfo(packageBytes []byte) (pkgs []analyzer.Package, err error) {

--- a/extractor/docker/docker.go
+++ b/extractor/docker/docker.go
@@ -340,8 +340,8 @@ func (d DockerExtractor) ExtractFiles(layer io.Reader, filenames []string) (extr
 			if s[len(s)-1] == '/' {
 				if filepath.Clean(s) == filepath.Dir(filePath) {
 					extract = true
+					break
 				}
-				break
 			}
 
 			if s == filePath || s == fileName || strings.HasPrefix(fileName, wh) {


### PR DESCRIPTION
Fix #29 
If `RequiredFiles()` contains a directory (which has a slash at the end), it always breaks the loop and can't extract files correctly.