### PR TITLE
fix docker reg with option SkipPing

### DIFF
--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -116,7 +116,8 @@ func RequiredFilenames() []string {
 func Analyze(ctx context.Context, imageName string, opts ...types.DockerOption) (fileMap extractor.FileMap, err error) {
 	// default docker option
 	opt := types.DockerOption{
-		Timeout: 600 * time.Second,
+		Timeout:  600 * time.Second,
+		SkipPing: true,
 	}
 	if len(opts) > 0 {
 		opt = opts[0]


### PR DESCRIPTION
Workaround for a deficient Ping implementation of reg package.
Ping fails on docker registries that return http 401
Authentication Required when requesting general /v2 url, but
happily allow unauthenticated pull of a specific image.

If there is any benefit of having Ping() enabled, it's not apparent.
Especially comparing it with how many registries are unusable with it.

Closes aquasecurity/trivy#229

Signed-off-by: Jakub Bielecki <jakub.bielecki@codilime.com>