### PR TITLE
add session token to DockerOption

### DIFF
--- a/extractor/docker/token/ecr/ecr.go
+++ b/extractor/docker/token/ecr/ecr.go
@@ -33,6 +33,7 @@ func getSession(option types.DockerOption) (*session.Session, error) {
 						credentials.Value{
 							AccessKeyID:     option.AwsAccessKey,
 							SecretAccessKey: option.AwsSecretKey,
+							SessionToken: option.AwsSessionToken,
 						},
 					),
 				},

--- a/types/docker.go
+++ b/types/docker.go
@@ -9,6 +9,7 @@ type DockerOption struct {
 	GcpCredPath  string
 	AwsAccessKey string
 	AwsSecretKey string
+	AwsSessionToken string
 	AwsRegion    string
 	Insecure     bool
 	Debug        bool


### PR DESCRIPTION
AWS SDK sometime needs session token when authorize it.
i.e.) https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html
