### PR TITLE
feat: support stdin

### DIFF
--- a/extractor/docker/docker.go
+++ b/extractor/docker/docker.go
@@ -69,13 +69,9 @@ func newDockerExtractor(ctx context.Context, imgRef image.Reference, transports 
 	ctx, cancel := context.WithTimeout(ctx, option.Timeout)
 	defer cancel()
 
-	img, err := image.NewImage(ctx, imgRef, transports, option)
+	img, cleanup, err := image.NewImage(ctx, imgRef, transports, option)
 	if err != nil {
 		return Extractor{}, nil, xerrors.Errorf("unable to initialize a image struct: %w", err)
-	}
-
-	cleanup := func() {
-		_ = img.Close()
 	}
 
 	return Extractor{

--- a/extractor/image/image_test.go
+++ b/extractor/image/image_test.go
@@ -158,7 +158,7 @@ func TestNewImage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			got, err := NewImage(ctx, tt.args.image, tt.args.transports, tt.args.option)
+			got, _, err := NewImage(ctx, tt.args.image, tt.args.transports, tt.args.option)
 			if tt.wantErr != "" {
 				require.NotNil(t, err, tt.name)
 				require.Contains(t, err.Error(), tt.wantErr, tt.name)
@@ -186,7 +186,7 @@ func TestRealImage_LayerIDs(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			img, err := NewImage(context.Background(), Reference{
+			img, _, err := NewImage(context.Background(), Reference{
 				Name:   tt.imageFile,
 				IsFile: true,
 			}, []string{"docker-archive:"}, types.DockerOption{})


### PR DESCRIPTION
fanal supported `-` before, but the feature was dropped when moving to `containers/image`. But some users want this feature, so this PR makes it possible to do it again.
Related to https://github.com/aquasecurity/trivy/pull/418