### PR TITLE
feat: split LayerID into Digest and DiffID

### DIFF
--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -174,6 +174,8 @@ func (ac Config) analyzeLayer(ctx context.Context, dig digest.Digest) (digest.Di
 	}
 
 	layerInfo := types.LayerInfo{
+		Digest:        string(dig),
+		DiffID:        string(decompressedLayerID),
 		SchemaVersion: types.LayerJSONSchemaVersion,
 		OS:            os,
 		PackageInfos:  pkgs,
@@ -232,7 +234,6 @@ func (a Applier) ApplyLayers(imageID digest.Digest, layerIDs []string) (types.Im
 		if layer.SchemaVersion == 0 {
 			return types.ImageDetail{}, xerrors.Errorf("layer cache missing: %s", layerID)
 		}
-		layer.ID = digest.Digest(layerID)
 		layers = append(layers, layer)
 	}
 

--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -66,6 +66,8 @@ func TestConfig_Analyze(t *testing.T) {
 						DecompressedLayerID: "sha256:77cae8ab23bf486355d1b3191259705374f4a11d483b24964d2f729dd8c076a0",
 						LayerInfo: types.LayerInfo{
 							SchemaVersion: 1,
+							Digest:        "sha256:77cae8ab23bf486355d1b3191259705374f4a11d483b24964d2f729dd8c076a0",
+							DiffID:        "sha256:77cae8ab23bf486355d1b3191259705374f4a11d483b24964d2f729dd8c076a0",
 							OS: &types.OS{
 								Family: "alpine",
 								Name:   "3.10.3",
@@ -118,6 +120,8 @@ func TestConfig_Analyze(t *testing.T) {
 						DecompressedLayerID: "sha256:d9441f7754ba1423ee11793b5db6390256e44097c2fc25e75a5fab19e6dc7911",
 						LayerInfo: types.LayerInfo{
 							SchemaVersion: 1,
+							Digest:        "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+							DiffID:        "sha256:d9441f7754ba1423ee11793b5db6390256e44097c2fc25e75a5fab19e6dc7911",
 							OS:            &types.OS{Family: "debian", Name: "9.9"},
 							PackageInfos:  []types.PackageInfo{{FilePath: "var/lib/dpkg/status.d/base", Packages: []types.Package{{Name: "base-files", Version: "9.9+deb9u9", Release: "", Epoch: 0, Arch: "", SrcName: "base-files", SrcVersion: "9.9+deb9u9", SrcRelease: "", SrcEpoch: 0}}}, {FilePath: "var/lib/dpkg/status.d/netbase", Packages: []types.Package{{Name: "netbase", Version: "5.4", Release: "", Epoch: 0, Arch: "", SrcName: "netbase", SrcVersion: "5.4", SrcRelease: "", SrcEpoch: 0}}}, {FilePath: "var/lib/dpkg/status.d/tzdata", Packages: []types.Package{{Name: "tzdata", Version: "2019a-0+deb9u1", Release: "", Epoch: 0, Arch: "", SrcName: "tzdata", SrcVersion: "2019a-0+deb9u1", SrcRelease: "", SrcEpoch: 0}}}},
 						},
@@ -129,6 +133,8 @@ func TestConfig_Analyze(t *testing.T) {
 						DecompressedLayerID: "sha256:dab15cac9ebd43beceeeda3ce95c574d6714ed3d3969071caead678c065813ec",
 						LayerInfo: types.LayerInfo{
 							SchemaVersion: 1,
+							Digest:        "sha256:dffd9992ca398466a663c87c92cfea2a2db0ae0cf33fcb99da60eec52addbfc5",
+							DiffID:        "sha256:dab15cac9ebd43beceeeda3ce95c574d6714ed3d3969071caead678c065813ec",
 							PackageInfos:  []types.PackageInfo{{FilePath: "var/lib/dpkg/status.d/libc6", Packages: []types.Package{{Name: "libc6", Version: "2.24-11+deb9u4", Release: "", Epoch: 0, Arch: "", SrcName: "glibc", SrcVersion: "2.24-11+deb9u4", SrcRelease: "", SrcEpoch: 0}}}, {FilePath: "var/lib/dpkg/status.d/libssl1", Packages: []types.Package{{Name: "libssl1.1", Version: "1.1.0k-1~deb9u1", Release: "", Epoch: 0, Arch: "", SrcName: "openssl", SrcVersion: "1.1.0k-1~deb9u1", SrcRelease: "", SrcEpoch: 0}}}, {FilePath: "var/lib/dpkg/status.d/openssl", Packages: []types.Package{{Name: "openssl", Version: "1.1.0k-1~deb9u1", Release: "", Epoch: 0, Arch: "", SrcName: "openssl", SrcVersion: "1.1.0k-1~deb9u1", SrcRelease: "", SrcEpoch: 0}}}},
 						},
 					},
@@ -139,6 +145,8 @@ func TestConfig_Analyze(t *testing.T) {
 						DecompressedLayerID: "sha256:24df0d4e20c0f42d3703bf1f1db2bdd77346c7956f74f423603d651e8e5ae8a7",
 						LayerInfo: types.LayerInfo{
 							SchemaVersion: 1,
+							Digest:        "sha256:24df0d4e20c0f42d3703bf1f1db2bdd77346c7956f74f423603d651e8e5ae8a7",
+							DiffID:        "sha256:24df0d4e20c0f42d3703bf1f1db2bdd77346c7956f74f423603d651e8e5ae8a7",
 							Applications: []types.Application{{Type: "composer", FilePath: "php-app/composer.lock",
 								Libraries: []types.LibraryInfo{
 									{Library: depTypes.Library{Name: "guzzlehttp/guzzle", Version: "6.2.0"}},
@@ -201,6 +209,8 @@ func TestConfig_Analyze(t *testing.T) {
 						DecompressedLayerID: "sha256:77cae8ab23bf486355d1b3191259705374f4a11d483b24964d2f729dd8c076a0",
 						LayerInfo: types.LayerInfo{
 							SchemaVersion: 1,
+							Digest:        "sha256:77cae8ab23bf486355d1b3191259705374f4a11d483b24964d2f729dd8c076a0",
+							DiffID:        "sha256:77cae8ab23bf486355d1b3191259705374f4a11d483b24964d2f729dd8c076a0",
 							OS: &types.OS{
 								Family: "alpine",
 								Name:   "3.10.3",
@@ -274,6 +284,8 @@ func TestApplier_ApplyLayers(t *testing.T) {
 					Returns: cache.LocalImageCacheGetLayerReturns{
 						LayerInfo: types.LayerInfo{
 							SchemaVersion: 1,
+							Digest:        "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+							DiffID:        "sha256:a187dde48cd289ac374ad8539930628314bc581a481cdb41409c9289419ddb72",
 							OS: &types.OS{
 								Family: "debian",
 								Name:   "9.9",
@@ -283,7 +295,6 @@ func TestApplier_ApplyLayers(t *testing.T) {
 									FilePath: "var/lib/dpkg/status.d/tzdata",
 									Packages: []types.Package{
 										{
-											LayerID:    "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
 											Name:       "tzdata",
 											Version:    "2019a-0+deb9u1",
 											SrcName:    "tzdata",
@@ -302,6 +313,8 @@ func TestApplier_ApplyLayers(t *testing.T) {
 					Returns: cache.LocalImageCacheGetLayerReturns{
 						LayerInfo: types.LayerInfo{
 							SchemaVersion: 1,
+							Digest:        "sha256:dffd9992ca398466a663c87c92cfea2a2db0ae0cf33fcb99da60eec52addbfc5",
+							DiffID:        "sha256:aad63a9339440e7c3e1fff2b988991b9bfb81280042fa7f39a5e327023056819",
 							PackageInfos: []types.PackageInfo{
 								{
 									FilePath: "var/lib/dpkg/status.d/libc6",
@@ -328,6 +341,8 @@ func TestApplier_ApplyLayers(t *testing.T) {
 					Returns: cache.LocalImageCacheGetLayerReturns{
 						LayerInfo: types.LayerInfo{
 							SchemaVersion: 1,
+							Digest:        "sha256:beee9f30bc1f711043e78d4a2be0668955d4b761d587d6f60c2c8dc081efb203",
+							DiffID:        "sha256:24df0d4e20c0f42d3703bf1f1db2bdd77346c7956f74f423603d651e8e5ae8a7",
 							Applications: []types.Application{
 								{
 									Type:     "composer",
@@ -372,11 +387,17 @@ func TestApplier_ApplyLayers(t *testing.T) {
 				Packages: []types.Package{
 					{
 						Name: "libc6", Version: "2.24-11+deb9u4", SrcName: "glibc", SrcVersion: "2.24-11+deb9u4",
-						LayerID: "sha256:dffd9992ca398466a663c87c92cfea2a2db0ae0cf33fcb99da60eec52addbfc5",
+						Layer: types.Layer{
+							Digest: "sha256:dffd9992ca398466a663c87c92cfea2a2db0ae0cf33fcb99da60eec52addbfc5",
+							DiffID: "sha256:aad63a9339440e7c3e1fff2b988991b9bfb81280042fa7f39a5e327023056819",
+						},
 					},
 					{
 						Name: "tzdata", Version: "2019a-0+deb9u1", SrcName: "tzdata", SrcVersion: "2019a-0+deb9u1",
-						LayerID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+						Layer: types.Layer{
+							Digest: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+							DiffID: "sha256:a187dde48cd289ac374ad8539930628314bc581a481cdb41409c9289419ddb72",
+						},
 					},
 				},
 				Applications: []types.Application{
@@ -388,14 +409,20 @@ func TestApplier_ApplyLayers(t *testing.T) {
 									Name:    "guzzlehttp/guzzle",
 									Version: "6.2.0",
 								},
-								LayerID: "sha256:24df0d4e20c0f42d3703bf1f1db2bdd77346c7956f74f423603d651e8e5ae8a7",
+								Layer: types.Layer{
+									Digest: "sha256:beee9f30bc1f711043e78d4a2be0668955d4b761d587d6f60c2c8dc081efb203",
+									DiffID: "sha256:24df0d4e20c0f42d3703bf1f1db2bdd77346c7956f74f423603d651e8e5ae8a7",
+								},
 							},
 							{
 								Library: depTypes.Library{
 									Name:    "symfony/process",
 									Version: "v4.2.7",
 								},
-								LayerID: "sha256:24df0d4e20c0f42d3703bf1f1db2bdd77346c7956f74f423603d651e8e5ae8a7",
+								Layer: types.Layer{
+									Digest: "sha256:beee9f30bc1f711043e78d4a2be0668955d4b761d587d6f60c2c8dc081efb203",
+									DiffID: "sha256:24df0d4e20c0f42d3703bf1f1db2bdd77346c7956f74f423603d651e8e5ae8a7",
+								},
 							},
 						},
 					},
@@ -418,6 +445,8 @@ func TestApplier_ApplyLayers(t *testing.T) {
 					Returns: cache.LocalImageCacheGetLayerReturns{
 						LayerInfo: types.LayerInfo{
 							SchemaVersion: 1,
+							Digest:        "sha256:a187dde48cd289ac374ad8539930628314bc581a481cdb41409c9289419ddb72",
+							DiffID:        "sha256:531743b7098cb2aaf615641007a129173f63ed86ca32fe7b5a246a1c47286028",
 							OS: &types.OS{
 								Family: "alpine",
 								Name:   "3.10.4",
@@ -426,11 +455,11 @@ func TestApplier_ApplyLayers(t *testing.T) {
 								{
 									FilePath: "lib/apk/db/installed",
 									Packages: []types.Package{
-										{Name: "musl", Version: "1.1.22-r3", LayerID: "sha256:531743b7098cb2aaf615641007a129173f63ed86ca32fe7b5a246a1c47286028"},
-										{Name: "busybox", Version: "1.30.1-r3", LayerID: "sha256:531743b7098cb2aaf615641007a129173f63ed86ca32fe7b5a246a1c47286028"},
-										{Name: "openssl", Version: "1.1.1d-r2", LayerID: "sha256:531743b7098cb2aaf615641007a129173f63ed86ca32fe7b5a246a1c47286028"},
-										{Name: "libcrypto1.1", Version: "1.1.1d-r2", LayerID: "sha256:531743b7098cb2aaf615641007a129173f63ed86ca32fe7b5a246a1c47286028"},
-										{Name: "libssl1.1", Version: "1.1.1d-r2", LayerID: "sha256:531743b7098cb2aaf615641007a129173f63ed86ca32fe7b5a246a1c47286028"},
+										{Name: "musl", Version: "1.1.22-r3"},
+										{Name: "busybox", Version: "1.30.1-r3"},
+										{Name: "openssl", Version: "1.1.1d-r2"},
+										{Name: "libcrypto1.1", Version: "1.1.1d-r2"},
+										{Name: "libssl1.1", Version: "1.1.1d-r2"},
 									},
 								},
 							},
@@ -466,11 +495,46 @@ func TestApplier_ApplyLayers(t *testing.T) {
 					Name:   "3.10.4",
 				},
 				Packages: []types.Package{
-					{Name: "busybox", Version: "1.30.1-r3", LayerID: "sha256:531743b7098cb2aaf615641007a129173f63ed86ca32fe7b5a246a1c47286028"},
-					{Name: "libcrypto1.1", Version: "1.1.1d-r2", LayerID: "sha256:531743b7098cb2aaf615641007a129173f63ed86ca32fe7b5a246a1c47286028"},
-					{Name: "libssl1.1", Version: "1.1.1d-r2", LayerID: "sha256:531743b7098cb2aaf615641007a129173f63ed86ca32fe7b5a246a1c47286028"},
-					{Name: "musl", Version: "1.1.22-r3", LayerID: "sha256:531743b7098cb2aaf615641007a129173f63ed86ca32fe7b5a246a1c47286028"},
-					{Name: "openssl", Version: "1.1.1d-r2", LayerID: "sha256:531743b7098cb2aaf615641007a129173f63ed86ca32fe7b5a246a1c47286028"},
+					{
+						Name:    "busybox",
+						Version: "1.30.1-r3",
+						Layer: types.Layer{
+							Digest: "sha256:a187dde48cd289ac374ad8539930628314bc581a481cdb41409c9289419ddb72",
+							DiffID: "sha256:531743b7098cb2aaf615641007a129173f63ed86ca32fe7b5a246a1c47286028",
+						},
+					},
+					{
+						Name:    "libcrypto1.1",
+						Version: "1.1.1d-r2",
+						Layer: types.Layer{
+							Digest: "sha256:a187dde48cd289ac374ad8539930628314bc581a481cdb41409c9289419ddb72",
+							DiffID: "sha256:531743b7098cb2aaf615641007a129173f63ed86ca32fe7b5a246a1c47286028",
+						},
+					},
+					{
+						Name:    "libssl1.1",
+						Version: "1.1.1d-r2",
+						Layer: types.Layer{
+							Digest: "sha256:a187dde48cd289ac374ad8539930628314bc581a481cdb41409c9289419ddb72",
+							DiffID: "sha256:531743b7098cb2aaf615641007a129173f63ed86ca32fe7b5a246a1c47286028",
+						},
+					},
+					{
+						Name:    "musl",
+						Version: "1.1.22-r3",
+						Layer: types.Layer{
+							Digest: "sha256:a187dde48cd289ac374ad8539930628314bc581a481cdb41409c9289419ddb72",
+							DiffID: "sha256:531743b7098cb2aaf615641007a129173f63ed86ca32fe7b5a246a1c47286028",
+						},
+					},
+					{
+						Name:    "openssl",
+						Version: "1.1.1d-r2",
+						Layer: types.Layer{
+							Digest: "sha256:a187dde48cd289ac374ad8539930628314bc581a481cdb41409c9289419ddb72",
+							DiffID: "sha256:531743b7098cb2aaf615641007a129173f63ed86ca32fe7b5a246a1c47286028",
+						},
+					},
 				},
 				HistoryPackages: []types.Package{
 					{Name: "musl", Version: "1.1.23"},

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -200,6 +200,8 @@ func TestFSCache_PutLayer(t *testing.T) {
 				decompressedLayerID: "sha256:dab15cac9ebd43beceeeda3ce95c574d6714ed3d3969071caead678c065813ec",
 				layerInfo: types.LayerInfo{
 					SchemaVersion: 1,
+					Digest:        "sha256:dffd9992ca398466a663c87c92cfea2a2db0ae0cf33fcb99da60eec52addbfc5",
+					DiffID:        "sha256:dab15cac9ebd43beceeeda3ce95c574d6714ed3d3969071caead678c065813ec",
 					OS: &types.OS{
 						Family: "alpine",
 						Name:   "3.10",
@@ -242,6 +244,8 @@ func TestFSCache_PutLayer(t *testing.T) {
 			want: `
 				{
 				  "SchemaVersion": 1,
+				  "Digest": "sha256:dffd9992ca398466a663c87c92cfea2a2db0ae0cf33fcb99da60eec52addbfc5",
+				  "DiffID": "sha256:dab15cac9ebd43beceeeda3ce95c574d6714ed3d3969071caead678c065813ec",
 				  "OS": {
 				    "Family": "alpine",
 				    "Name": "3.10"
@@ -252,7 +256,8 @@ func TestFSCache_PutLayer(t *testing.T) {
 				      "Packages": [
 				        {
 				          "Name": "musl",
-				          "Version": "1.1.22-r3"
+				          "Version": "1.1.22-r3",
+						  "Layer": {}
 				        }
 				      ]
 				    }
@@ -266,13 +271,15 @@ func TestFSCache_PutLayer(t *testing.T) {
                            "Library":{
                               "Name":"guzzlehttp/guzzle",
                               "Version":"6.2.0"
-                           }
+                           },
+						   "Layer": {}
                         },
                         {
                            "Library":{
                               "Name":"guzzlehttp/promises",
                               "Version":"v1.3.1"
-                           }
+                           },
+						   "Layer": {}
                         }
 				      ]
 				    }
@@ -375,7 +382,8 @@ func TestFSCache_PutImage(t *testing.T) {
 				  "HistoryPackages": [
 				    {
 				      "Name": "musl",
-				      "Version": "1.2.3"
+				      "Version": "1.2.3",
+					  "Layer": {}
 				    }
 				  ]
 				}

--- a/extractor/docker/docker_test.go
+++ b/extractor/docker/docker_test.go
@@ -6,10 +6,9 @@ import (
 	"testing"
 
 	godeptypes "github.com/aquasecurity/go-dep-parser/pkg/types"
+	digest "github.com/opencontainers/go-digest"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/opencontainers/go-digest"
 
 	"github.com/stretchr/testify/require"
 
@@ -29,7 +28,8 @@ func TestApplyLayers(t *testing.T) {
 			inputLayers: []types.LayerInfo{
 				{
 					SchemaVersion: 1,
-					ID:            "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+					Digest:        "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+					DiffID:        "sha256:a187dde48cd289ac374ad8539930628314bc581a481cdb41409c9289419ddb72",
 					OS: &types.OS{
 						Family: "alpine",
 						Name:   "3.10",
@@ -75,7 +75,8 @@ func TestApplyLayers(t *testing.T) {
 				},
 				{
 					SchemaVersion: 1,
-					ID:            "sha256:24df0d4e20c0f42d3703bf1f1db2bdd77346c7956f74f423603d651e8e5ae8a7",
+					Digest:        "sha256:24df0d4e20c0f42d3703bf1f1db2bdd77346c7956f74f423603d651e8e5ae8a7",
+					DiffID:        "sha256:aad63a9339440e7c3e1fff2b988991b9bfb81280042fa7f39a5e327023056819",
 					PackageInfos: []types.PackageInfo{
 						{
 							FilePath: "lib/apk/db/installed",
@@ -97,7 +98,8 @@ func TestApplyLayers(t *testing.T) {
 				},
 				{
 					SchemaVersion: 1,
-					ID:            "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4",
+					Digest:        "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4",
+					DiffID:        "sha256:a187dde48cd289ac374ad8539930628314bc581a481cdb41409c9289419ddb72",
 					PackageInfos: []types.PackageInfo{
 						{
 							FilePath: "lib/apk/db/installed",
@@ -127,13 +129,19 @@ func TestApplyLayers(t *testing.T) {
 						Name:    "musl",
 						Version: "1.2.4",
 						Release: "4.5.8",
-						LayerID: "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4",
+						Layer: types.Layer{
+							Digest: "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4",
+							DiffID: "sha256:a187dde48cd289ac374ad8539930628314bc581a481cdb41409c9289419ddb72",
+						},
 					},
 					{
 						Name:    "openssl",
 						Version: "1.2.3",
 						Release: "4.5.6",
-						LayerID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+						Layer: types.Layer{
+							Digest: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+							DiffID: "sha256:a187dde48cd289ac374ad8539930628314bc581a481cdb41409c9289419ddb72",
+						},
 					},
 				},
 				Applications: []types.Application{
@@ -146,7 +154,10 @@ func TestApplyLayers(t *testing.T) {
 									Name:    "gemlibrary1",
 									Version: "1.2.3",
 								},
-								LayerID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+								Layer: types.Layer{
+									Digest: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+									DiffID: "sha256:a187dde48cd289ac374ad8539930628314bc581a481cdb41409c9289419ddb72",
+								},
 							},
 						},
 					},
@@ -158,7 +169,8 @@ func TestApplyLayers(t *testing.T) {
 			inputLayers: []types.LayerInfo{
 				{
 					SchemaVersion: 1,
-					ID:            "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+					Digest:        "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+					DiffID:        "sha256:a187dde48cd289ac374ad8539930628314bc581a481cdb41409c9289419ddb72",
 					OS: &types.OS{
 						Family: "alpine",
 						Name:   "3.10",
@@ -198,7 +210,8 @@ func TestApplyLayers(t *testing.T) {
 				},
 				{
 					SchemaVersion: 1,
-					ID:            "sha256:24df0d4e20c0f42d3703bf1f1db2bdd77346c7956f74f423603d651e8e5ae8a7",
+					Digest:        "sha256:24df0d4e20c0f42d3703bf1f1db2bdd77346c7956f74f423603d651e8e5ae8a7",
+					DiffID:        "sha256:aad63a9339440e7c3e1fff2b988991b9bfb81280042fa7f39a5e327023056819",
 					Applications: []types.Application{
 						{
 							Type:     "gem",
@@ -249,14 +262,20 @@ func TestApplyLayers(t *testing.T) {
 									Name:    "rack",
 									Version: "4.0.0",
 								},
-								LayerID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+								Layer: types.Layer{
+									Digest: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+									DiffID: "sha256:a187dde48cd289ac374ad8539930628314bc581a481cdb41409c9289419ddb72",
+								},
 							},
 							{
 								Library: godeptypes.Library{
 									Name:    "rails",
 									Version: "6.0.0",
 								},
-								LayerID: "sha256:24df0d4e20c0f42d3703bf1f1db2bdd77346c7956f74f423603d651e8e5ae8a7",
+								Layer: types.Layer{
+									Digest: "sha256:24df0d4e20c0f42d3703bf1f1db2bdd77346c7956f74f423603d651e8e5ae8a7",
+									DiffID: "sha256:aad63a9339440e7c3e1fff2b988991b9bfb81280042fa7f39a5e327023056819",
+								},
 							},
 						},
 					},
@@ -269,7 +288,10 @@ func TestApplyLayers(t *testing.T) {
 									Name:    "phplibrary1",
 									Version: "6.6.6",
 								},
-								LayerID: "sha256:24df0d4e20c0f42d3703bf1f1db2bdd77346c7956f74f423603d651e8e5ae8a7",
+								Layer: types.Layer{
+									Digest: "sha256:24df0d4e20c0f42d3703bf1f1db2bdd77346c7956f74f423603d651e8e5ae8a7",
+									DiffID: "sha256:aad63a9339440e7c3e1fff2b988991b9bfb81280042fa7f39a5e327023056819",
+								},
 							},
 						},
 					},
@@ -281,7 +303,8 @@ func TestApplyLayers(t *testing.T) {
 			inputLayers: []types.LayerInfo{
 				{
 					SchemaVersion: 1,
-					ID:            "sha256:24df0d4e20c0f42d3703bf1f1db2bdd77346c7956f74f423603d651e8e5ae8a7",
+					Digest:        "sha256:24df0d4e20c0f42d3703bf1f1db2bdd77346c7956f74f423603d651e8e5ae8a7",
+					DiffID:        "sha256:aad63a9339440e7c3e1fff2b988991b9bfb81280042fa7f39a5e327023056819",
 					OS: &types.OS{
 						Family: "debian",
 						Name:   "8",
@@ -315,7 +338,8 @@ func TestApplyLayers(t *testing.T) {
 				},
 				{
 					SchemaVersion: 1,
-					ID:            "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+					Digest:        "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+					DiffID:        "sha256:a187dde48cd289ac374ad8539930628314bc581a481cdb41409c9289419ddb72",
 					PackageInfos: []types.PackageInfo{
 						{
 							FilePath: "var/lib/dpkg/status.d/libc",
@@ -338,16 +362,22 @@ func TestApplyLayers(t *testing.T) {
 				},
 				Packages: []types.Package{
 					{
-						LayerID: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
 						Name:    "libc",
 						Version: "1.2.4",
 						Release: "4.5.7",
+						Layer: types.Layer{
+							Digest: "sha256:932da51564135c98a49a34a193d6cd363d8fa4184d957fde16c9d8527b3f3b02",
+							DiffID: "sha256:a187dde48cd289ac374ad8539930628314bc581a481cdb41409c9289419ddb72",
+						},
 					},
 					{
-						LayerID: "sha256:24df0d4e20c0f42d3703bf1f1db2bdd77346c7956f74f423603d651e8e5ae8a7",
 						Name:    "openssl",
 						Version: "1.2.3",
 						Release: "4.5.6",
+						Layer: types.Layer{
+							Digest: "sha256:24df0d4e20c0f42d3703bf1f1db2bdd77346c7956f74f423603d651e8e5ae8a7",
+							DiffID: "sha256:aad63a9339440e7c3e1fff2b988991b9bfb81280042fa7f39a5e327023056819",
+						},
 					},
 				},
 			},

--- a/types/image.go
+++ b/types/image.go
@@ -14,17 +14,22 @@ type OS struct {
 	Name   string
 }
 
+type Layer struct {
+	Digest string `json:",omitempty"`
+	DiffID string `json:",omitempty"`
+}
+
 type Package struct {
-	Name       string        `json:",omitempty"`
-	Version    string        `json:",omitempty"`
-	Release    string        `json:",omitempty"`
-	Epoch      int           `json:",omitempty"`
-	Arch       string        `json:",omitempty"`
-	SrcName    string        `json:",omitempty"`
-	SrcVersion string        `json:",omitempty"`
-	SrcRelease string        `json:",omitempty"`
-	SrcEpoch   int           `json:",omitempty"`
-	LayerID    digest.Digest `json:",omitempty"`
+	Name       string `json:",omitempty"`
+	Version    string `json:",omitempty"`
+	Release    string `json:",omitempty"`
+	Epoch      int    `json:",omitempty"`
+	Arch       string `json:",omitempty"`
+	SrcName    string `json:",omitempty"`
+	SrcVersion string `json:",omitempty"`
+	SrcRelease string `json:",omitempty"`
+	SrcEpoch   int    `json:",omitempty"`
+	Layer      Layer  `json:",omitempty"`
 }
 
 type SrcPackage struct {
@@ -40,7 +45,7 @@ type PackageInfo struct {
 
 type LibraryInfo struct {
 	Library godeptypes.Library `json:",omitempty"`
-	LayerID digest.Digest      `json:",omitempty"`
+	Layer   Layer              `json:",omitempty"`
 }
 
 type Application struct {
@@ -78,8 +83,9 @@ type ImageInfo struct {
 
 // LayerInfo is stored in cache
 type LayerInfo struct {
-	ID            digest.Digest `json:",omitempty"`
 	SchemaVersion int
+	Digest        string        `json:",omitempty"`
+	DiffID        string        `json:",omitempty"`
 	OS            *OS           `json:",omitempty"`
 	PackageInfos  []PackageInfo `json:",omitempty"`
 	Applications  []Application `json:",omitempty"`


### PR DESCRIPTION
Currently, we handle the ID of a layer as single `LayerID`, but there are two types of ID, `Digest` and `DiffID`.

`DiffID` is mainly used in Docker Engine.
https://github.com/moby/moby/blob/master/image/spec/v1.2.md#terminology

`Digest` is used in Docker Registry.
https://docs.docker.com/registry/spec/manifest-v2-2/#manifest-list-field-descriptions

Their difference between them is whether the layer is compressed. I thought that it would be better for the future to handle them separately.