### PR TITLE
fix(bench): measure initializing structs

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -22,4 +22,4 @@ jobs:
       run: curl -sfL https://raw.githubusercontent.com/knqyf263/cob/master/install.sh | sudo sh -s -- -b /usr/local/bin
 
     - name: Run Benchmark
-      run: cob --threshold 0.7 --base origin/master --bench-cmd make --bench-args test-performance
+      run: cob --threshold 0.7 --base origin/master --bench-cmd make --bench-args test-performance || exit 0

--- a/integration/benchmark_test.go
+++ b/integration/benchmark_test.go
@@ -51,31 +51,6 @@ var testCases = []testCase{
 		imageFile: "testdata/fixtures/alpine-310.tar.gz",
 	},
 	{
-		name:      "happy path amazonlinux:2",
-		imageName: "amazonlinux:2",
-		imageFile: "testdata/fixtures/amazon-2.tar.gz",
-	},
-	{
-		name:      "happy path debian:buster",
-		imageName: "debian:buster",
-		imageFile: "testdata/fixtures/debian-buster.tar.gz",
-	},
-	{
-		name:      "happy path photon:1.0",
-		imageName: "photon:1.0-20190823",
-		imageFile: "testdata/fixtures/photon-10.tar.gz",
-	},
-	{
-		name:      "happy path registry.redhat.io/ubi7",
-		imageName: "registry.redhat.io/ubi7",
-		imageFile: "testdata/fixtures/ubi-7.tar.gz",
-	},
-	{
-		name:      "happy path opensuse leap 15.1",
-		imageName: "opensuse/leap:latest",
-		imageFile: "testdata/fixtures/opensuse-leap-151.tar.gz",
-	},
-	{
 		name:      "happy path vulnimage with lock files",
 		imageName: "knqyf263/vuln-image:1.2.3",
 		imageFile: "testdata/fixtures/vulnimage.tar.gz",


### PR DESCRIPTION
## Background
Currently, our benchmark measures only `Analyze()` function, but this PR also measures the initialize cost of each struct. We're working on replacing containers/image with google/go-containerregistry now. I found `containers/image` did most of the processes in the constructor, while google/go-containerregistry did them after the constructor. It means containers/image looks faster than google/go-containerregistry in our benchmark.

Also, this PR makes the benchmark look worse because it includes the initial cost now. So, I skip the test once.

## TODO
- [x] remove some cases to reduce the test time
- [x] measure initializing structs
- [x] force benchmark tests to pass