### PR TITLE
Close open connections and files

### DIFF
--- a/image/daemon/image.go
+++ b/image/daemon/image.go
@@ -38,6 +38,11 @@ func Image(ref name.Reference) (v1.Image, func(), error) {
 	if err != nil {
 		return nil, cleanup, xerrors.Errorf("failed to initialize a docker client: %w", err)
 	}
+	defer func() {
+		if err != nil {
+			c.Close()
+		}
+	}()
 
 	inspect, _, err := c.ImageInspectWithRaw(context.Background(), ref.Name())
 	if err != nil {
@@ -50,6 +55,8 @@ func Image(ref name.Reference) (v1.Image, func(), error) {
 	}
 
 	cleanup = func() {
+		c.Close()
+		f.Close()
 		_ = os.Remove(f.Name())
 	}
 


### PR DESCRIPTION
Ensure that the client and file is closed either in error cases or once cleanup() is called so no file descriptors are leaked.

If ImageInspectWithRaw
https://github.com/aquasecurity/fanal/blob/1b5f79c38073afe1a11ee19fe1f1095535dc6ce8/image/daemon/image.go#L42
fails the docker client is not closed, and thus will leak filedescriptors to the underlying network connection to docker.
This happens when you reuse the fanal code in a long-running process.

Unfortunately I don't know of a good automated test case, it can be tested by shelling out to lsof to count open files, e.g. in
https://github.com/aquasecurity/fanal/blob/master/image/image_test.go

Example Test
```go
func countOpenFiles() int {
	out, err := exec.Command("/bin/sh", "-c", fmt.Sprintf("lsof -p %v", os.Getpid())).Output()
	if err != nil {
		log.Fatal(err)
	}
	lines := strings.Split(string(out), "\n")
	return len(lines) - 1
}


func TestFdLeak(t *testing.T) {
	for i := 0; i<1000; i++ {
		_, cleanup, err := NewDockerImage(context.Background(), "alpine:3.11", types.DockerOption{})
		cleanup()
		log.Println(err, i, countOpenFiles())
	}
}
```