### PR TITLE
feat: Analyzer for user defined packages.

### DIFF
--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/aquasecurity/fanal/analyzer"
 	_ "github.com/aquasecurity/fanal/analyzer/library/bundler"
+	_ "github.com/aquasecurity/fanal/analyzer/library/manifest"
 	aos "github.com/aquasecurity/fanal/analyzer/os"
 	_ "github.com/aquasecurity/fanal/analyzer/os/alpine"
 	_ "github.com/aquasecurity/fanal/analyzer/os/ubuntu"
@@ -260,6 +261,26 @@ func TestAnalyzeFile(t *testing.T) {
 						FilePath: "/lib/apk/db/installed",
 						Packages: []types.Package{
 							{Name: "musl", Version: "1.1.24-r2", SrcName: "musl", SrcVersion: "1.1.24-r2"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "happy path with manifest.trivy file",
+			args: args{
+				filePath: "/etc/manifest.trivy",
+				opener: func() ([]byte, error) {
+					return ioutil.ReadFile("testdata/etc/manifest.trivy")
+				},
+			},
+			want: &analyzer.AnalysisResult{
+				PackageInfos: []types.PackageInfo{
+					{
+						FilePath: "/etc/manifest.trivy",
+						Packages: []types.Package{
+							{Name: "php", Version: "7.4.11"},
+							{Name: "curl", Version: "7.72.0"},
 						},
 					},
 				},

--- a/analyzer/library/const.go
+++ b/analyzer/library/const.go
@@ -8,6 +8,7 @@ const (
 	Pipenv   = "pipenv"
 	Poetry   = "poetry"
 	Yarn     = "yarn"
+	Manifest = "pkg-manifest"
 )
 
 var (

--- a/analyzer/library/manifest/manifest.go
+++ b/analyzer/library/manifest/manifest.go
@@ -1,0 +1,78 @@
+package manifest
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/aquasecurity/fanal/analyzer"
+	"github.com/aquasecurity/fanal/analyzer/library"
+	"github.com/aquasecurity/fanal/types"
+	"github.com/aquasecurity/fanal/utils"
+	"golang.org/x/xerrors"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+func init() {
+	analyzer.RegisterAnalyzer(&pkgManifestAnalyzer{})
+}
+
+var requiredFiles = []string{"manifest.trivy"}
+
+type pkgManifestAnalyzer struct{}
+
+type PkgManifestEntry struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+func (a pkgManifestAnalyzer) Analyze(content []byte) (analyzer.AnalyzeReturn, error) {
+	result, err := parse(bytes.NewBuffer(content))
+
+	if err != nil {
+		return analyzer.AnalyzeReturn{}, xerrors.Errorf("unable to parse manifest.trivy: %w", err)
+	}
+	return analyzer.AnalyzeReturn{
+		Packages: result,
+	}, nil
+}
+
+func parse(r io.Reader) ([]types.Package, error) {
+	decoder := json.NewDecoder(r)
+	// The manifest.trivy file is a json file with objects which
+	// used the `types.Package` structure. This to make it possible to use either or
+	// all the properties that is supported.
+	// The most important ones are though, of course, version and name.
+	var result []types.Package
+	err := decoder.Decode(&result)
+
+	if err != nil {
+		return nil, err
+	}
+
+	var pkgs []types.Package
+	unique := map[string]struct{}{}
+
+	for _, pkg := range result {
+		symbol := fmt.Sprintf("%s@%s", pkg.Name, pkg.Version)
+
+		if _, ok := unique[symbol]; ok {
+			continue
+		}
+
+		pkgs = append(pkgs, pkg)
+		unique[symbol] = struct{}{}
+	}
+
+	return pkgs, nil
+}
+
+func (a pkgManifestAnalyzer) Required(filePath string, _ os.FileInfo) bool {
+	fileName := filepath.Base(filePath)
+	return utils.StringInSlice(fileName, requiredFiles)
+}
+
+func (a pkgManifestAnalyzer) Name() string {
+	return library.Manifest
+}

--- a/analyzer/testdata/etc/manifest.trivy
+++ b/analyzer/testdata/etc/manifest.trivy
@@ -1,0 +1,4 @@
+[
+  {"name": "php", "version": "7.4.11" },
+  {"name": "curl", "version": "7.72.0" }
+]

--- a/cmd/fanal/main.go
+++ b/cmd/fanal/main.go
@@ -15,6 +15,7 @@ import (
 	_ "github.com/aquasecurity/fanal/analyzer/library/bundler"
 	_ "github.com/aquasecurity/fanal/analyzer/library/cargo"
 	_ "github.com/aquasecurity/fanal/analyzer/library/composer"
+	_ "github.com/aquasecurity/fanal/analyzer/library/manifest"
 	_ "github.com/aquasecurity/fanal/analyzer/library/npm"
 	_ "github.com/aquasecurity/fanal/analyzer/library/pipenv"
 	_ "github.com/aquasecurity/fanal/analyzer/library/poetry"


### PR DESCRIPTION
Hi there!
When building docker images, I often build most of the software from source instead of downloading them from a package registry.  
Looking at issues like https://github.com/aquasecurity/trivy/issues/481 in the Trivy repository, make me think that I'm not alone.

This pull request contains a simple analyzer which adds packages to scan from a json file (currently named `/etc/manifest.trivy` open for better naming!). The json file uses the `types.Package` in `types/image.go` as resource in the decoder, although it only requires the name and version to work.

I added a test for it in the `analyzer_test.go` file, and could not find more tests which tests the analyzers, please let me know (if the PR is wanted) if I missed anything when it comes to the tests!