### PR TITLE
Feat: Created analyzer for NuGet lockfiles.

### DIFF
--- a/analyzer/library/const.go
+++ b/analyzer/library/const.go
@@ -5,6 +5,7 @@ const (
 	Cargo    = "cargo"
 	Composer = "composer"
 	Npm      = "npm"
+	NuGet    = "nuget"
 	Pipenv   = "pipenv"
 	Poetry   = "poetry"
 	Yarn     = "yarn"

--- a/analyzer/library/nuget/nuget.go
+++ b/analyzer/library/nuget/nuget.go
@@ -1,13 +1,15 @@
 package nuget
 
 import (
+	"os"
+	"path/filepath"
+
+	"golang.org/x/xerrors"
+
 	"github.com/aquasecurity/fanal/analyzer"
 	"github.com/aquasecurity/fanal/analyzer/library"
 	"github.com/aquasecurity/fanal/utils"
 	"github.com/aquasecurity/go-dep-parser/pkg/nuget"
-	"golang.org/x/xerrors"
-	"os"
-	"path/filepath"
 )
 
 func init() {

--- a/analyzer/library/nuget/nuget.go
+++ b/analyzer/library/nuget/nuget.go
@@ -1,0 +1,36 @@
+package nuget
+
+import (
+	"github.com/aquasecurity/fanal/analyzer"
+	"github.com/aquasecurity/fanal/analyzer/library"
+	"github.com/aquasecurity/fanal/utils"
+	"github.com/aquasecurity/go-dep-parser/pkg/nuget"
+	"golang.org/x/xerrors"
+	"os"
+	"path/filepath"
+)
+
+func init() {
+	analyzer.RegisterAnalyzer(&nugetLibraryAnalyzer{})
+}
+
+var requiredFiles = []string{"packages.lock.json"}
+
+type nugetLibraryAnalyzer struct{}
+
+func (a nugetLibraryAnalyzer) Analyze(content []byte) (analyzer.AnalyzeReturn, error) {
+	ret, err := library.Analyze(content, nuget.Parse)
+	if err != nil {
+		return analyzer.AnalyzeReturn{}, xerrors.Errorf("unable to parse packages.lock.json: %w", err)
+	}
+	return ret, nil
+}
+
+func (a nugetLibraryAnalyzer) Required(filePath string, _ os.FileInfo) bool {
+	fileName := filepath.Base(filePath)
+	return utils.StringInSlice(fileName, requiredFiles)
+}
+
+func (a nugetLibraryAnalyzer) Name() string {
+	return library.NuGet
+}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/GoogleCloudPlatform/docker-credential-gcr v1.5.0
 	github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5 // indirect
-	github.com/aquasecurity/go-dep-parser v0.0.0-20190819075924-ea223f0ef24b
+	github.com/aquasecurity/go-dep-parser v0.0.0-20201028043324-889d4a92b8e0
 	github.com/aquasecurity/testdocker v0.0.0-20200426142840-5f05bce6f12a
 	github.com/aws/aws-sdk-go v1.27.1
 	github.com/deckarep/golang-set v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,8 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
-github.com/aquasecurity/go-dep-parser v0.0.0-20190819075924-ea223f0ef24b h1:55Ulc/gvfWm4ylhVaR7MxOwujRjA6et7KhmUbSgUFf4=
-github.com/aquasecurity/go-dep-parser v0.0.0-20190819075924-ea223f0ef24b/go.mod h1:BpNTD9vHfrejKsED9rx04ldM1WIbeyXGYxUrqTVwxVQ=
+github.com/aquasecurity/go-dep-parser v0.0.0-20201028043324-889d4a92b8e0 h1:cLH3SebzhbJ+jU1GIad8A1N8p7m7OjHhtY6JePISiVc=
+github.com/aquasecurity/go-dep-parser v0.0.0-20201028043324-889d4a92b8e0/go.mod h1:X42mTIRhgPalSm81Om2kD+3ydeunbC8TZtZj1bvgRo8=
 github.com/aquasecurity/testdocker v0.0.0-20200426142840-5f05bce6f12a h1:hsw7PpiymXP64evn/K7gsj3hWzMqLrdoeE6JkqDocVg=
 github.com/aquasecurity/testdocker v0.0.0-20200426142840-5f05bce6f12a/go.mod h1:psfu0MVaiTDLpNxCoNsTeILSKY2EICBwv345f3M+Ffs=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=


### PR DESCRIPTION
This pull requests include a new analyzer for NuGet `packages.lock.json` files.  
It's basically the same as the other analyzers, but makes use of the NuGet parser which is included in the following `go-dep-parser` [pull request](https://github.com/aquasecurity/go-dep-parser/pull/14).

For reference, feature request issue can be found here: https://github.com/aquasecurity/trivy/issues/681