### PR TITLE
WIP: fix fanal execution on Windows

### DIFF
--- a/walker/tar.go
+++ b/walker/tar.go
@@ -31,6 +31,7 @@ func WalkLayerTar(layer io.Reader, analyzeFn WalkFunc) ([]string, []string, erro
 
 		filePath := hdr.Name
 		filePath = strings.TrimLeft(filepath.Clean(filePath), "/")
+		filePath = filepath.ToSlash(filePath)
 		fileDir, fileName := filepath.Split(filePath)
 
 		// e.g. etc/.wh..wh..opq
@@ -42,6 +43,7 @@ func WalkLayerTar(layer io.Reader, analyzeFn WalkFunc) ([]string, []string, erro
 		if strings.HasPrefix(fileName, wh) {
 			name := strings.TrimPrefix(fileName, wh)
 			fpath := filepath.Join(fileDir, name)
+			fpath = filepath.ToSlash(fpath)
 			whFiles = append(whFiles, fpath)
 			continue
 		}

--- a/walker/walk_test.go
+++ b/walker/walk_test.go
@@ -24,4 +24,8 @@ func Test_isIgnore(t *testing.T) {
 	for _, fp := range []string{"foo", "foo/bar"} {
 		assert.False(t, isIgnored(fp))
 	}
+
+	for _, fp := range []string{"foo/.git", "foo/node_modules"} {
+		assert.True(t, isIgnored(fp))
+	}
 }

--- a/walker/walk_windows_test.go
+++ b/walker/walk_windows_test.go
@@ -1,0 +1,15 @@
+package walker
+
+import (
+	"testing"
+
+	"github.com/aquasecurity/fanal/analyzer/library"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_isIgnore(t *testing.T) {
+	for _, fp := range []string{`foo\.git`, `foo\node_modules`} {
+		assert.True(t, isIgnored(fp))
+	}
+}


### PR DESCRIPTION
resolves #125

fix `filepath.Clean` and `filepath.Join` on Windows

tested:
- [x] `fanal img`
- [ ] `fanal ar`
- [ ] `fanal fs`
- [ ] `fanal repo`