### PR TITLE
fix(gomod): fix a panic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Microsoft/go-winio v0.4.16 // indirect
 	github.com/Microsoft/hcsshim v0.8.14 // indirect
 	github.com/alicebob/miniredis/v2 v2.14.1
-	github.com/aquasecurity/go-dep-parser v0.0.0-20210427143403-3c97ccc53976
+	github.com/aquasecurity/go-dep-parser v0.0.0-20210520015931-0dd56983cc62
 	github.com/aquasecurity/testdocker v0.0.0-20210106133225-0b17fe083674
 	github.com/aws/aws-sdk-go v1.31.6
 	github.com/containerd/cgroups v0.0.0-20210114181951-8a68de567b68 // indirect

--- a/go.sum
+++ b/go.sum
@@ -159,8 +159,8 @@ github.com/apparentlymart/go-textseg v1.0.0 h1:rRmlIsPEEhUTIKQb7T++Nz/A5Q6C9IuX2
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
 github.com/apparentlymart/go-textseg/v12 v12.0.0 h1:bNEQyAGak9tojivJNkoqWErVCQbjdL7GzRt3F8NvfJ0=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
-github.com/aquasecurity/go-dep-parser v0.0.0-20210427143403-3c97ccc53976 h1:ypl/IDxujzEymmwtzGJqQyboI2oZr1se+OoYaGqgBzQ=
-github.com/aquasecurity/go-dep-parser v0.0.0-20210427143403-3c97ccc53976/go.mod h1:Cv/FOCXy6gwvDbz/KX48+y//SmbnKroFwW5hquXn5G4=
+github.com/aquasecurity/go-dep-parser v0.0.0-20210520015931-0dd56983cc62 h1:aahEMQZXrwhpCMlDgXi2d7jJVNDTpYGJOgLyNptGQoY=
+github.com/aquasecurity/go-dep-parser v0.0.0-20210520015931-0dd56983cc62/go.mod h1:Cv/FOCXy6gwvDbz/KX48+y//SmbnKroFwW5hquXn5G4=
 github.com/aquasecurity/testdocker v0.0.0-20210106133225-0b17fe083674 h1:Xq/HxWFGaB4G/prC6czH/F5woB91GMCCilJxs/5DnDk=
 github.com/aquasecurity/testdocker v0.0.0-20210106133225-0b17fe083674/go.mod h1:psfu0MVaiTDLpNxCoNsTeILSKY2EICBwv345f3M+Ffs=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=


### PR DESCRIPTION
## Issue/PR
- https://github.com/aquasecurity/trivy/issues/1004
- https://github.com/aquasecurity/go-dep-parser/pull/33

## Output
It works with `quay.io/eclipse/che-plugin-sidecar@sha256:8615a29435b0256bffaf85ab2cf9327b059f14eaa6614346dfd51e3a6dd9f041` now.
```
$ ./fanal image quay.io/eclipse/che-plugin-sidecar@sha256:8615a29435b0256bffaf85ab2cf9327b059f14eaa6614346dfd51e3a6dd9f041
quay.io/eclipse/che-plugin-sidecar@sha256:8615a29435b0256bffaf85ab2cf9327b059f14eaa6614346dfd51e3a6dd9f041
RepoTags: []
RepoDigests: [quay.io/eclipse/che-plugin-sidecar@sha256:8615a29435b0256bffaf85ab2cf9327b059f14eaa6614346dfd51e3a6dd9f041]
&{Family:debian Name:9.13}
via image Packages: 188
gomod (usr/local/go/src/cmd/go.sum): 12
gomod (usr/local/go/src/go.sum): 5
gobinary (usr/local/go/bin/golangci-lint): 71
gobinary (go/bin/gopls): 11
gomod (go/pkg/mod/honnef.co/go/tools@v0.0.1-2020.1.6/go.sum): 18
gomod (go/pkg/mod/mvdan.cc/gofumpt@v0.0.0-20200927160801-5bfeb2e70dd6/go.sum): 16
gomod (go/pkg/mod/mvdan.cc/xurls/v2@v2.2.0/go.sum): 6
gomod (go/pkg/mod/github.com/google/go-cmp@v0.5.1/go.sum): 1
gomod (go/pkg/mod/github.com/sergi/go-diff@v1.1.0/go.sum): 9
gomod (go/pkg/mod/golang.org/x/mod@v0.3.0/go.sum): 7
gomod (go/pkg/mod/golang.org/x/tools/gopls@v0.0.0-20201109182053-3db8fd265862/go.sum): 27
gomod (go/pkg/mod/golang.org/x/tools@v0.0.0-20201109182053-3db8fd265862/go.sum): 9
gomod (go/src/github.com/davidrjenni/reftools/go.sum): 6
gomod (go/src/github.com/fatih/gomodifytags/go.sum): 3
gomod (go/src/github.com/rogpeppe/godef/go.sum): 9
gomod (go/src/github.com/cweill/gotests/go.sum): 7
gomod (go/src/github.com/josharian/impl/go.sum): 9
gomod (go/src/github.com/karrick/godirwalk/examples/find-fast/go.sum): 3
gomod (go/src/github.com/stamblerre/gocode/go.sum): 8
gomod (go/src/github.com/uudashr/gopkgs/v2/go.sum): 2
gomod (go/src/github.com/uudashr/gopkgs/go.sum): 2
gomod (go/src/github.com/zmb3/gogetdoc/go.sum): 1
gomod (go/src/github.com/go-delve/delve/go.sum): 32
gomod (go/src/golang.org/x/tools/go.sum): 9
gomod (go/src/golang.org/x/tools/gopls/go.sum): 27
gomod (go/src/golang.org/x/lint/go.sum): 8
gomod (go/src/golang.org/x/mod/go.sum): 7
gomod (go/src/golang.org/x/net/go.sum): 5
gomod (go/src/golang.org/x/net/http2/h2demo/go.sum): 45
```
