### PR TITLE
feat: Support Google artifact registry

### DIFF
--- a/image/token/google/google.go
+++ b/image/token/google/google.go
@@ -1,4 +1,4 @@
-package gcr
+package google
 
 import (
 	"context"
@@ -18,11 +18,14 @@ type GCR struct {
 	domain string
 }
 
+// Google container registry
 const gcrURL = "gcr.io"
+// Google artifact registry
+const garURL = "docker.pkg.dev"
 
 func (g *GCR) CheckOptions(domain string, d types.DockerOption) error {
-	if !strings.HasSuffix(domain, gcrURL) {
-		return xerrors.Errorf("GCR : %w", types.InvalidURLPattern)
+	if !strings.HasSuffix(domain, gcrURL) && !strings.HasSuffix(domain, garURL) {
+		return xerrors.Errorf("Google registry: %w", types.InvalidURLPattern)
 	}
 	g.domain = domain
 	if d.GcpCredPath != "" {

--- a/image/token/google/google.go
+++ b/image/token/google/google.go
@@ -13,17 +13,18 @@ import (
 	"github.com/GoogleCloudPlatform/docker-credential-gcr/store"
 )
 
-type GCR struct {
+type Registry struct {
 	Store  store.GCRCredStore
 	domain string
 }
 
 // Google container registry
 const gcrURL = "gcr.io"
+
 // Google artifact registry
 const garURL = "docker.pkg.dev"
 
-func (g *GCR) CheckOptions(domain string, d types.DockerOption) error {
+func (g *Registry) CheckOptions(domain string, d types.DockerOption) error {
 	if !strings.HasSuffix(domain, gcrURL) && !strings.HasSuffix(domain, garURL) {
 		return xerrors.Errorf("Google registry: %w", types.InvalidURLPattern)
 	}
@@ -34,7 +35,7 @@ func (g *GCR) CheckOptions(domain string, d types.DockerOption) error {
 	return nil
 }
 
-func (g *GCR) GetCredential(ctx context.Context) (username, password string, err error) {
+func (g *Registry) GetCredential(ctx context.Context) (username, password string, err error) {
 	var credStore store.GCRCredStore
 	if g.Store == nil {
 		credStore, err = store.DefaultGCRCredStore()

--- a/image/token/google/google_test.go
+++ b/image/token/google/google_test.go
@@ -1,4 +1,4 @@
-package gcr
+package google
 
 import (
 	"reflect"

--- a/image/token/google/google_test.go
+++ b/image/token/google/google_test.go
@@ -15,7 +15,7 @@ func TestCheckOptions(t *testing.T) {
 	var tests = map[string]struct {
 		domain  string
 		opt     types.DockerOption
-		gcr     *GCR
+		gcr     *Registry
 		wantErr error
 	}{
 		"InvalidURL": {
@@ -26,17 +26,17 @@ func TestCheckOptions(t *testing.T) {
 		"NoOption": {
 			domain: "gcr.io",
 			opt:    types.DockerOption{},
-			gcr:    &GCR{domain: "gcr.io"},
+			gcr:    &Registry{domain: "gcr.io"},
 		},
 		"CredOption": {
 			domain: "gcr.io",
 			opt:    types.DockerOption{GcpCredPath: "/path/to/file.json"},
-			gcr:    &GCR{domain: "gcr.io", Store: store.NewGCRCredStore("/path/to/file.json")},
+			gcr:    &Registry{domain: "gcr.io", Store: store.NewGCRCredStore("/path/to/file.json")},
 		},
 	}
 
 	for testname, v := range tests {
-		g := &GCR{}
+		g := &Registry{}
 		err := g.CheckOptions(v.domain, v.opt)
 		if v.wantErr != nil {
 			if err == nil {

--- a/image/token/token.go
+++ b/image/token/token.go
@@ -4,8 +4,7 @@ import (
 	"context"
 
 	"github.com/aquasecurity/fanal/image/token/ecr"
-	"github.com/aquasecurity/fanal/image/token/gcr"
-
+	"github.com/aquasecurity/fanal/image/token/google"
 	"github.com/google/go-containerregistry/pkg/authn"
 
 	"github.com/aquasecurity/fanal/types"
@@ -16,7 +15,7 @@ var (
 )
 
 func init() {
-	RegisterRegistry(&gcr.GCR{})
+	RegisterRegistry(&google.GCR{})
 	RegisterRegistry(&ecr.ECR{})
 }
 

--- a/image/token/token.go
+++ b/image/token/token.go
@@ -15,7 +15,7 @@ var (
 )
 
 func init() {
-	RegisterRegistry(&google.GCR{})
+	RegisterRegistry(&google.Registry{})
 	RegisterRegistry(&ecr.ECR{})
 }
 


### PR DESCRIPTION
This commit adds the capability to scan images from Google artifact
registry(GAR). GAR domains were earlier rejected by Trivy e.g.
europe-west3-docker.pkg.dev etc. With this change, we will treat domain
ending with 'docker.pkg.dev' as GAR domain and use gcloud sdk to fetch
credentials from provided file or credstore.