### PR TITLE
Support for aqua custom javascript analyser

### DIFF
--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -31,6 +31,7 @@ type AnalysisTarget struct {
 	Dir      string
 	FilePath string
 	Content  []byte
+	Ctx      context.Context
 }
 
 type analyzer interface {
@@ -211,7 +212,7 @@ func (a Analyzer) AnalyzeFile(ctx context.Context, wg *sync.WaitGroup, limit *se
 				return
 			}
 			result.Merge(ret)
-		}(d, AnalysisTarget{Dir: dir, FilePath: filePath, Content: b})
+		}(d, AnalysisTarget{Dir: dir, FilePath: filePath, Content: b, Ctx: ctx})
 	}
 	return nil
 }

--- a/artifact/image/image_test.go
+++ b/artifact/image/image_test.go
@@ -559,3 +559,33 @@ func TestArtifact_Inspect(t *testing.T) {
 		})
 	}
 }
+
+func TestPostProcessorJs(t *testing.T) {
+	tests := []struct {
+		name        string
+		libraryInfo []types.Application
+		want        []types.Application
+	}{
+		{
+			name: "happy path",
+			libraryInfo: []types.Application{
+				{Type: types.JavaScript, FilePath: "/home/node/test_1/bootstrap.js", Libraries: []types.LibraryInfo{{Library: depTypes.Library{Name: "twitter-bootstrap", Version: "3.2.0"}}}},
+				{Type: types.JavaScript, FilePath: "/home/node/test_2/maths.js", Libraries: []types.LibraryInfo{{Library: depTypes.Library{Name: "math", Version: "1.5.8"}}}},
+				{Type: types.Npm, FilePath: "/home/node/test_2/package-lock.json", Libraries: []types.LibraryInfo{{Library: depTypes.Library{Name: "pretty", Version: "2.0.0"}}, {Library: depTypes.Library{Name: "sqlstring", Version: "2.3.1"}}, {Library: depTypes.Library{Name: "caseless", Version: "0.15.1"}}}},
+				{Type: types.JavaScript, FilePath: "/home/node/test_3/src/validate.js", Libraries: []types.LibraryInfo{{Library: depTypes.Library{Name: "validate", Version: "0.5.2"}}}},
+				{Type: types.Npm, FilePath: "/home/node/test_3/package-lock.json", Libraries: []types.LibraryInfo{{Library: depTypes.Library{Name: "is-whitespace", Version: "0.3.0"}}, {Library: depTypes.Library{Name: "verror", Version: "1.10.1"}}, {Library: depTypes.Library{Name: "assert-plus", Version: "1.0.2"}}}},
+			},
+			want: []types.Application{
+				{Type: types.JavaScript, FilePath: "/home/node/test_1/bootstrap.js", Libraries: []types.LibraryInfo{{Library: depTypes.Library{Name: "twitter-bootstrap", Version: "3.2.0"}}}},
+				{Type: types.Npm, FilePath: "/home/node/test_2/package-lock.json", Libraries: []types.LibraryInfo{{Library: depTypes.Library{Name: "pretty", Version: "2.0.0"}}, {Library: depTypes.Library{Name: "sqlstring", Version: "2.3.1"}}, {Library: depTypes.Library{Name: "caseless", Version: "0.15.1"}}}},
+				{Type: types.Npm, FilePath: "/home/node/test_3/package-lock.json", Libraries: []types.LibraryInfo{{Library: depTypes.Library{Name: "is-whitespace", Version: "0.3.0"}}, {Library: depTypes.Library{Name: "verror", Version: "1.10.1"}}, {Library: depTypes.Library{Name: "assert-plus", Version: "1.0.2"}}}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := image2.PostProcessorJs(tt.libraryInfo)
+			assert.Equal(t, tt.want, a)
+		})
+	}
+}

--- a/types/const.go
+++ b/types/const.go
@@ -7,17 +7,18 @@ const (
 
 const (
 	// Programming language dependencies
-	Bundler  = "bundler"
-	Cargo    = "cargo"
-	Composer = "composer"
-	Npm      = "npm"
-	NuGet    = "nuget"
-	Pipenv   = "pipenv"
-	Poetry   = "poetry"
-	Yarn     = "yarn"
-	Jar      = "jar"
-	GoBinary = "gobinary"
-	GoMod    = "gomod"
+	Bundler    = "bundler"
+	Cargo      = "cargo"
+	Composer   = "composer"
+	Npm        = "npm"
+	NuGet      = "nuget"
+	Pipenv     = "pipenv"
+	Poetry     = "poetry"
+	Yarn       = "yarn"
+	Jar        = "jar"
+	GoBinary   = "gobinary"
+	GoMod      = "gomod"
+	JavaScript = "javascript"
 
 	// Config files
 	YAML           = "yaml"


### PR DESCRIPTION
1. Pass context object to analyse function
2. Implement post processing func which excludes Javascript libraries if same js path exists for any NPM package
3. New constant to support Javascript and test cases