### PR TITLE
feat(python): support .egg directory format

### DIFF
--- a/analyzer/language/python/packaging/packaging.go
+++ b/analyzer/language/python/packaging/packaging.go
@@ -21,7 +21,12 @@ const version = 1
 
 var (
 	requiredFiles = []string{
-		// egg
+		// .egg format
+		// https://setuptools.readthedocs.io/en/latest/deprecated/python_eggs.html#eggs-and-their-formats
+		"EGG-INFO/PKG-INFO",
+
+		// .egg-info format: .egg-info can be a file or directory
+		// https://setuptools.readthedocs.io/en/latest/deprecated/python_eggs.html#eggs-and-their-formats
 		".egg-info",
 		".egg-info/PKG-INFO",
 

--- a/analyzer/language/python/packaging/packaging_test.go
+++ b/analyzer/language/python/packaging/packaging_test.go
@@ -114,6 +114,11 @@ func Test_packagingAnalyzer_Required(t *testing.T) {
 		want     bool
 	}{
 		{
+			name:     "egg",
+			filePath: "python2.7/site-packages/cssutils-1.0-py2.7.egg/EGG-INFO/PKG-INFO",
+			want:     true,
+		},
+		{
 			name:     "egg-info",
 			filePath: "python3.8/site-packages/wrapt-1.12.1.egg-info",
 			want:     true,


### PR DESCRIPTION
## Overview
Python Eggs has two formats
- .egg format
- .egg-info format


Currently, fanal supports only `.egg-info` format. This PR adds support of `.egg` directory format. `.egg` file will be supported in another PR.

## Reference
https://setuptools.readthedocs.io/en/latest/deprecated/python_eggs.html#eggs-and-their-formats