### PR TITLE
fix(filter): handle the leading slash

### DIFF
--- a/hook/filter/filter_test.go
+++ b/hook/filter/filter_test.go
@@ -97,7 +97,7 @@ func Test_systemFileFilterHook_Hook(t *testing.T) {
 					"/usr/lib64/python2.7/distutils/command/install_egg_info.pyc",
 					"/usr/lib64/python2.7/distutils/command/install_egg_info.pyo",
 					"/usr/lib64/python2.7/lib-dynload/Python-2.7.5-py2.7.egg-info",
-					"/usr/lib64/python2.7/wsgiref.egg-info",
+					"usr/lib64/python2.7/wsgiref.egg-info", // without the leading slash
 				},
 			},
 			want: &types.BlobInfo{


### PR DESCRIPTION
## Overview
In the case of Alpine Linux, installed files don't have the leading slash, while Red Hat and Debian have.

```
/app # apk info -L python | grep egg-info
usr/lib/python2.7/wsgiref.egg-info
usr/lib/python2.7/lib-dynload/Python-2.7.15-py2.7.egg-info
```

We have to handle both cases.