### PR TITLE
fix(configfile-OS): Enriched config file metadata with OS value

### DIFF
--- a/image/daemon/image.go
+++ b/image/daemon/image.go
@@ -105,6 +105,7 @@ func (img *image) ConfigFile() (*v1.ConfigFile, error) {
 
 	return &v1.ConfigFile{
 		Architecture:  img.inspect.Architecture,
+		OS:            img.inspect.Os,
 		Author:        img.inspect.Author,
 		Created:       v1.Time{Time: created},
 		DockerVersion: img.inspect.DockerVersion,

--- a/image/daemon/image_test.go
+++ b/image/daemon/image_test.go
@@ -81,6 +81,7 @@ func Test_image_ConfigFile(t *testing.T) {
 			imageName: "alpine:3.11",
 			want: &v1.ConfigFile{
 				Architecture:  "amd64",
+				OS:            "linux",
 				Created:       v1.Time{Time: time.Date(2020, 3, 23, 21, 19, 34, 196162891, time.UTC)},
 				DockerVersion: "18.09.7",
 				History: []v1.History{
@@ -107,6 +108,7 @@ func Test_image_ConfigFile(t *testing.T) {
 			imageName: "gcr.io/distroless/base",
 			want: &v1.ConfigFile{
 				Architecture: "amd64",
+				OS:           "linux",
 				Author:       "Bazel",
 				Created:      v1.Time{Time: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)},
 				History: []v1.History{

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -75,6 +75,7 @@ func TestNewDockerImage(t *testing.T) {
 			wantRepoTags: []string{"alpine:3.11"},
 			wantConfigFile: &v1.ConfigFile{
 				Architecture:  "amd64",
+				OS:            "linux",
 				Created:       v1.Time{Time: time.Date(2020, 3, 23, 21, 19, 34, 196162891, time.UTC)},
 				DockerVersion: "18.09.7",
 				History: []v1.History{


### PR DESCRIPTION
The OS Name collected from docker inspect will be set to v1.ConfigFile.OS. 
This avoid empty value for OS field.