### PR TITLE
fix(go-binary): skip large files

### DIFF
--- a/analyzer/language/golang/binary/binary.go
+++ b/analyzer/language/golang/binary/binary.go
@@ -36,6 +36,11 @@ func (a gobinaryLibraryAnalyzer) Required(_ string, fileInfo os.FileInfo) bool {
 		return false
 	}
 
+	const MaxFileSize = 200000000
+	if fileInfo.Size() > MaxFileSize {
+		return false
+	}
+
 	// Check executable file
 	if mode.Perm()&0111 != 0 {
 		return true

--- a/analyzer/language/golang/binary/binary.go
+++ b/analyzer/language/golang/binary/binary.go
@@ -16,7 +16,11 @@ func init() {
 	analyzer.RegisterAnalyzer(&gobinaryLibraryAnalyzer{})
 }
 
-const version = 1
+const (
+	version     = 1
+	MiB         = 1024 * 1024
+	MaxFileSize = 200 * MiB
+)
 
 type gobinaryLibraryAnalyzer struct{}
 
@@ -36,11 +40,9 @@ func (a gobinaryLibraryAnalyzer) Required(_ string, fileInfo os.FileInfo) bool {
 		return false
 	}
 
-	const MaxFileSize = 200000000
 	if fileInfo.Size() > MaxFileSize {
 		return false
 	}
-
 	// Check executable file
 	if mode.Perm()&0111 != 0 {
 		return true


### PR DESCRIPTION
Add skipping large files whose size is more than 200MB.

Fixes [aquasecurity/trivy#1242](https://github.com/aquasecurity/trivy/issues/1242)