### PR TITLE
fix(rpm): don't panic when parse source rpm name failed

### DIFF
--- a/analyzer/pkg/rpm/rpm.go
+++ b/analyzer/pkg/rpm/rpm.go
@@ -1,7 +1,9 @@
 package rpm
 
 import (
+	"errors"
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -24,6 +26,7 @@ var requiredFiles = []string{
 	"usr/lib/sysimage/rpm/Packages",
 	"var/lib/rpm/Packages",
 }
+var errUnexpectedNameFormat = errors.New("unexpected name format")
 
 type rpmPkgAnalyzer struct{}
 
@@ -84,7 +87,10 @@ func (a rpmPkgAnalyzer) parsePkgInfo(packageBytes []byte) ([]types.Package, []st
 		var srcName, srcVer, srcRel string
 		if pkg.SourceRpm != "(none)" && pkg.SourceRpm != "" {
 			// source epoch is not included in SOURCERPM
-			srcName, srcVer, srcRel = splitFileName(pkg.SourceRpm)
+			srcName, srcVer, srcRel, err = splitFileName(pkg.SourceRpm)
+			if err != nil {
+				log.Printf("Invalid Source RPM Found: %s", pkg.SourceRpm)
+			}
 		}
 
 		files, err := pkg.InstalledFiles()
@@ -117,21 +123,30 @@ func (a rpmPkgAnalyzer) parsePkgInfo(packageBytes []byte) ([]types.Package, []st
 //    foo-1.0-1.i386.rpm returns foo, 1.0, 1, i386
 //    1:bar-9-123a.ia64.rpm returns bar, 9, 123a, 1, ia64
 // https://github.com/rpm-software-management/yum/blob/043e869b08126c1b24e392f809c9f6871344c60d/rpmUtils/miscutils.py#L301
-func splitFileName(filename string) (name, ver, rel string) {
+func splitFileName(filename string) (name, ver, rel string, err error) {
 	if strings.HasSuffix(filename, ".rpm") {
 		filename = filename[:len(filename)-4]
 	}
 
 	archIndex := strings.LastIndex(filename, ".")
+	if archIndex == -1 {
+		return "", "", "", errUnexpectedNameFormat
+	}
 
 	relIndex := strings.LastIndex(filename[:archIndex], "-")
+	if relIndex == -1 {
+		return "", "", "", errUnexpectedNameFormat
+	}
 	rel = filename[relIndex+1 : archIndex]
 
 	verIndex := strings.LastIndex(filename[:relIndex], "-")
+	if verIndex == -1 {
+		return "", "", "", errUnexpectedNameFormat
+	}
 	ver = filename[verIndex+1 : relIndex]
 
 	name = filename[:verIndex]
-	return name, ver, rel
+	return name, ver, rel, nil
 }
 
 func (a rpmPkgAnalyzer) Required(filePath string, _ os.FileInfo) bool {

--- a/analyzer/pkg/rpm/rpm.go
+++ b/analyzer/pkg/rpm/rpm.go
@@ -1,13 +1,12 @@
 package rpm
 
 import (
-	"errors"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/aquasecurity/fanal/log"
 	rpmdb "github.com/knqyf263/go-rpmdb/pkg"
 	"golang.org/x/xerrors"
 
@@ -26,7 +25,7 @@ var requiredFiles = []string{
 	"usr/lib/sysimage/rpm/Packages",
 	"var/lib/rpm/Packages",
 }
-var errUnexpectedNameFormat = errors.New("unexpected name format")
+var errUnexpectedNameFormat = xerrors.New("unexpected name format")
 
 type rpmPkgAnalyzer struct{}
 
@@ -89,7 +88,7 @@ func (a rpmPkgAnalyzer) parsePkgInfo(packageBytes []byte) ([]types.Package, []st
 			// source epoch is not included in SOURCERPM
 			srcName, srcVer, srcRel, err = splitFileName(pkg.SourceRpm)
 			if err != nil {
-				log.Printf("Invalid Source RPM Found: %s", pkg.SourceRpm)
+				log.Logger.Debugf("Invalid Source RPM Found: %s", pkg.SourceRpm)
 			}
 		}
 

--- a/analyzer/pkg/rpm/rpm_test.go
+++ b/analyzer/pkg/rpm/rpm_test.go
@@ -600,22 +600,25 @@ func TestParseRpmInfo(t *testing.T) {
 }
 
 func Test_splitFileName(t *testing.T) {
-	type args struct {
-		filename string
-	}
 	tests := []struct {
 		name     string
-		args     args
+		filename string
 		wantName string
 		wantVer  string
 		wantRel  string
 		wantErr  bool
 	}{
 		{
-			name: "invalid name",
-			args: args{
-				filename: "elasticsearch-5.6.16-1-src.rpm",
-			},
+			name:     "valid name",
+			filename: "glibc-2.17-307.el7.1.src.rpm",
+			wantName: "glibc",
+			wantVer:  "2.17",
+			wantRel:  "307.el7.1",
+			wantErr:  false,
+		},
+		{
+			name:     "invalid name",
+			filename: "elasticsearch-5.6.16-1-src.rpm",
 			wantName: "",
 			wantVer:  "",
 			wantRel:  "",
@@ -624,20 +627,15 @@ func Test_splitFileName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotName, gotVer, gotRel, err := splitFileName(tt.args.filename)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("splitFileName() error = %v, wantErr %v", err, tt.wantErr)
-				return
+			gotName, gotVer, gotRel, err := splitFileName(tt.filename)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
 			}
-			if gotName != tt.wantName {
-				t.Errorf("splitFileName() gotName = %v, want %v", gotName, tt.wantName)
-			}
-			if gotVer != tt.wantVer {
-				t.Errorf("splitFileName() gotVer = %v, want %v", gotVer, tt.wantVer)
-			}
-			if gotRel != tt.wantRel {
-				t.Errorf("splitFileName() gotRel = %v, want %v", gotRel, tt.wantRel)
-			}
+			assert.Equal(t, tt.wantName, gotName)
+			assert.Equal(t, tt.wantVer, gotVer)
+			assert.Equal(t, tt.wantRel, gotRel)
 		})
 	}
 }

--- a/analyzer/pkg/rpm/rpm_test.go
+++ b/analyzer/pkg/rpm/rpm_test.go
@@ -598,3 +598,46 @@ func TestParseRpmInfo(t *testing.T) {
 		})
 	}
 }
+
+func Test_splitFileName(t *testing.T) {
+	type args struct {
+		filename string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		wantName string
+		wantVer  string
+		wantRel  string
+		wantErr  bool
+	}{
+		{
+			name: "invalid name",
+			args: args{
+				filename: "elasticsearch-5.6.16-1-src.rpm",
+			},
+			wantName: "",
+			wantVer:  "",
+			wantRel:  "",
+			wantErr:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotName, gotVer, gotRel, err := splitFileName(tt.args.filename)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("splitFileName() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotName != tt.wantName {
+				t.Errorf("splitFileName() gotName = %v, want %v", gotName, tt.wantName)
+			}
+			if gotVer != tt.wantVer {
+				t.Errorf("splitFileName() gotVer = %v, want %v", gotVer, tt.wantVer)
+			}
+			if gotRel != tt.wantRel {
+				t.Errorf("splitFileName() gotRel = %v, want %v", gotRel, tt.wantRel)
+			}
+		})
+	}
+}


### PR DESCRIPTION
https://github.com/aquasecurity/trivy/issues/1172  
Fixes #212

Before:

```
panic: runtime error: slice bounds out of range [:-1]

goroutine 2306 [running]:
github.com/aquasecurity/fanal/analyzer/pkg/rpm.splitFileName(0xc00004ad80, 0x1a, 0x50, 0xc002347000, 0x50, 0x50, 0xc0006bdc2f, 0x6)
        /go/src/github.com/aquasecurity/fanal/analyzer/pkg/rpm/rpm.go:133 +0x1f1
github.cogor/pkg/rpm.rpmPkgAnalyzer.parsePkgInfo(0xc00b75c000, 0x1211000, 0x1530000, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        /go/src/github.com/aquasecurity/fanal/analyzer/pkg/rpm/rpm.go:87 +0xb17
github.cogor/pkg/rpm.rpmPkgAnalyzer.Analyze(0x0, 0x0, 0xc002f194d0, 0x14, 0xc00b75c000, 0x1211000, 0x1530000, 0x2, 0xc009c6e4e0, 0x11eaeda)
        /go/src/github.com/aquasecurity/fanal/analyzer/pkg/rpm/rpm.go:31 +0x5a
github.cogor.Analyzer.AnalyzeFile.func1(0xc0008c8000, 0xc00013a350, 0xc0003aa000, 0x265b168, 0x3073f48, 0x0, 0x0, 0xc002f194d0, 0x14, 0xc00b75c000, ...)
        /go/src/github.com/aquasecurity/fanal/analyzer/analyzer.go:212 +0xe6
created bgonal/analyzer.Analyzer.AnalyzeFile
        /go/src/github.com/aquasecurity/fanal/analyzer/analyzer.go:208 +0x333
```

After:

```
2021/10/02 12:14:26 Invalid Source RPM Found: elasticsearch-5.6.16-1-src.rpm
```