### PR TITLE
fix(daemon): handle nil config

### DIFF
--- a/image/daemon/image.go
+++ b/image/daemon/image.go
@@ -172,6 +172,10 @@ func (img *image) diffIDs() ([]v1.Hash, error) {
 }
 
 func (img *image) imageConfig(config *container.Config) v1.Config {
+	if config == nil {
+		return v1.Config{}
+	}
+
 	c := v1.Config{
 		AttachStderr:    config.AttachStderr,
 		AttachStdin:     config.AttachStdin,


### PR DESCRIPTION
It is possible that `Config` is nil and it causes panic.

```
docker inspect registry.redhat.io/rhel7:7.0-27                                                                                   [~/src/github.com/aquasecurity/fanal]
[
    {
        "Id": "sha256:bc668af2b27f909aa48aeb12194483bdf165e44b4879c7b89b39c75f48d6fa0f",
        "RepoTags": [
            "registry.redhat.io/rhel7:7.0-27"
        ],
        "RepoDigests": [
            "registry.redhat.io/rhel7@sha256:489b7ba5ed0c9f63d85fd94b990f52b719f2bde006a0df168d2999fc771e5cca"
        ],
        "Parent": "",
        "Comment": "Created by Image Factory",
        "Created": "2015-02-10T09:12:45Z",
        "Container": "",
        "ContainerConfig": {
            "Hostname": "",
            "Domainname": "",
            "User": "",
            "AttachStdin": false,
            "AttachStdout": false,
            "AttachStderr": false,
            "Tty": false,
            "OpenStdin": false,
            "StdinOnce": false,
            "Env": null,
            "Cmd": null,
            "Image": "",
            "Volumes": null,
            "WorkingDir": "",
            "Entrypoint": null,
            "OnBuild": null,
            "Labels": null
        },
        "DockerVersion": "0.11.1",
        "Author": "",
        "Config": null,
        ...
]
```