### PR TITLE
allow suppressing the git clone output by setting the quiet option

### DIFF
--- a/artifact/artifact.go
+++ b/artifact/artifact.go
@@ -14,6 +14,7 @@ type Option struct {
 	DisabledHooks     []hook.Type
 	SkipFiles         []string
 	SkipDirs          []string
+	Quiet             bool
 }
 
 func (o *Option) Sort() {

--- a/artifact/remote/git.go
+++ b/artifact/remote/git.go
@@ -35,11 +35,18 @@ func NewArtifact(rawurl string, c cache.ArtifactCache, artifactOpt artifact.Opti
 		return nil, cleanup, err
 	}
 
-	_, err = git.PlainClone(tmpDir, false, &git.CloneOptions{
+	cloneOptions := git.CloneOptions{
 		URL:      u.String(),
 		Progress: os.Stdout,
 		Depth:    1,
-	})
+	}
+
+	// suppress clone output if quiet
+	if artifactOpt.Quiet {
+		cloneOptions.Progress = nil
+	}
+
+	_, err = git.PlainClone(tmpDir, false, &cloneOptions)
 	if err != nil {
 		return nil, cleanup, xerrors.Errorf("git error: %w", err)
 	}

--- a/artifact/remote/git_test.go
+++ b/artifact/remote/git_test.go
@@ -38,6 +38,7 @@ func TestNewArtifact(t *testing.T) {
 	type args struct {
 		rawurl string
 		c      cache.ArtifactCache
+		quiet  bool
 	}
 	tests := []struct {
 		name    string
@@ -49,6 +50,15 @@ func TestNewArtifact(t *testing.T) {
 			args: args{
 				rawurl: ts.URL + "/test.git",
 				c:      nil,
+				quiet:  false,
+			},
+		},
+		{
+			name: "happy quiet",
+			args: args{
+				rawurl: ts.URL + "/test.git",
+				c:      nil,
+				quiet:  true,
 			},
 		},
 		{
@@ -56,6 +66,7 @@ func TestNewArtifact(t *testing.T) {
 			args: args{
 				rawurl: ts.URL + "/unknown.git",
 				c:      nil,
+				quiet:  false,
 			},
 			wantErr: true,
 		},
@@ -64,6 +75,7 @@ func TestNewArtifact(t *testing.T) {
 			args: args{
 				rawurl: "ht tp://foo.com",
 				c:      nil,
+				quiet:  false,
 			},
 			wantErr: true,
 		},
@@ -71,7 +83,7 @@ func TestNewArtifact(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, cleanup, err := NewArtifact(tt.args.rawurl, tt.args.c, artifact.Option{}, config.ScannerOption{})
+			_, cleanup, err := NewArtifact(tt.args.rawurl, tt.args.c, artifact.Option{Quiet: tt.args.quiet}, config.ScannerOption{})
 			assert.Equal(t, tt.wantErr, err != nil)
 			defer cleanup()
 		})


### PR DESCRIPTION
Hi,

this is my proposal to support #334 which is needed to fix trivy issue [928](https://ghttps://github.com/aquasecurity/trivy/issues/927ithub.com/aquasecurity/trivy/issues/927).

Given the current architecture I found it easiest to extend the artifact options for this use case even tough the option probably doesn't fit a 100 % in there.

Any feedback is much appreciated.
