### PR TITLE
fix: fixed skipFiles/skipDirs flags for relative path

### DIFF
--- a/artifact/local/fs.go
+++ b/artifact/local/fs.go
@@ -54,7 +54,7 @@ func NewArtifact(dir string, c cache.ArtifactCache, artifactOpt artifact.Option,
 	return Artifact{
 		dir:         dir,
 		cache:       c,
-		walker:      walker.NewDir(artifactOpt.SkipFiles, artifactOpt.SkipDirs),
+		walker:      walker.NewDir(buildAbsPaths(dir, artifactOpt.SkipFiles), buildAbsPaths(dir, artifactOpt.SkipDirs)),
 		analyzer:    analyzer.NewAnalyzer(artifactOpt.DisabledAnalyzers),
 		hookManager: hook.NewManager(artifactOpt.DisabledHooks),
 		scanner:     s,
@@ -62,6 +62,18 @@ func NewArtifact(dir string, c cache.ArtifactCache, artifactOpt artifact.Option,
 		artifactOption:      artifactOpt,
 		configScannerOption: scannerOpt,
 	}, nil
+}
+
+func buildAbsPaths(base string, paths []string) []string {
+	absPaths := []string{}
+	for _, path := range paths {
+		if filepath.IsAbs(path) {
+			absPaths = append(absPaths, path)
+		} else {
+			absPaths = append(absPaths, filepath.Join(base, path))
+		}
+	}
+	return absPaths
 }
 
 func (a Artifact) Inspect(ctx context.Context) (types.ArtifactReference, error) {

--- a/artifact/local/fs_test.go
+++ b/artifact/local/fs_test.go
@@ -155,3 +155,32 @@ func TestArtifact_Inspect(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildAbsPath(t *testing.T) {
+	tests := []struct {
+		name          string
+		base          string
+		paths         []string
+		expectedPaths []string
+	}{
+		{"absolute path", "/testBase", []string{"/testPath"}, []string{"/testPath"}},
+		{"relative path", "/testBase", []string{"testPath"}, []string{"/testBase/testPath"}},
+		{"path have '.'", "/testBase", []string{"./testPath"}, []string{"/testBase/testPath"}},
+		{"path have '..'", "/testBase", []string{"../testPath/"}, []string{"/testPath"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := buildAbsPaths(test.base, test.paths)
+			if len(test.paths) != len(got) {
+				t.Errorf("paths not equals, expected: %s, got: %s", test.expectedPaths, got)
+			} else {
+				for i, path := range test.expectedPaths {
+					if path != got[i] {
+						t.Errorf("paths not equals, expected: %s, got: %s", test.expectedPaths, got)
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes [trivy issue1479](https://github.com/aquasecurity/trivy/issues/1479)