### PR TITLE
feat(java): support offline mode

### DIFF
--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -372,6 +372,7 @@ func TestAnalyzeFile(t *testing.T) {
 					}
 					return os.Open(tt.args.testFilePath)
 				},
+				analyzer.AnalysisOptions{},
 			)
 
 			wg.Wait()

--- a/analyzer/config/cloudformation/cloudformation.go
+++ b/analyzer/config/cloudformation/cloudformation.go
@@ -30,8 +30,8 @@ func NewConfigAnalyzer() ConfigAnalyzer {
 }
 
 // Analyze returns a results of CloudFormation file
-func (a ConfigAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTarget) (*analyzer.AnalysisResult, error) {
-	content, err := io.ReadAll(target.Content)
+func (a ConfigAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
+	content, err := io.ReadAll(input.Content)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to read the CloudFormation file: %w", err)
 	}
@@ -41,7 +41,7 @@ func (a ConfigAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTarge
 			Configs: []types.Config{
 				{
 					Type:     types.CloudFormation,
-					FilePath: filepath.Join(target.Dir, target.FilePath),
+					FilePath: filepath.Join(input.Dir, input.FilePath),
 				},
 			},
 		}, nil

--- a/analyzer/config/cloudformation/cloudformation_test.go
+++ b/analyzer/config/cloudformation/cloudformation_test.go
@@ -125,7 +125,7 @@ spec:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			a := ConfigAnalyzer{}
-			got, err := a.Analyze(context.Background(), analyzer.AnalysisTarget{
+			got, err := a.Analyze(context.Background(), analyzer.AnalysisInput{
 				FilePath: tt.filePath,
 				Content:  tt.content,
 			})

--- a/analyzer/config/docker/docker.go
+++ b/analyzer/config/docker/docker.go
@@ -30,17 +30,17 @@ func NewConfigAnalyzer(filePattern *regexp.Regexp) ConfigAnalyzer {
 	}
 }
 
-func (s ConfigAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTarget) (*analyzer.AnalysisResult, error) {
-	parsed, err := s.parser.Parse(target.Content)
+func (s ConfigAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
+	parsed, err := s.parser.Parse(input.Content)
 	if err != nil {
-		return nil, xerrors.Errorf("unable to parse Dockerfile (%s): %w", target.FilePath, err)
+		return nil, xerrors.Errorf("unable to parse Dockerfile (%s): %w", input.FilePath, err)
 	}
 
 	return &analyzer.AnalysisResult{
 		Configs: []types.Config{
 			{
 				Type:     types.Dockerfile,
-				FilePath: target.FilePath,
+				FilePath: input.FilePath,
 				Content:  parsed,
 			},
 		},

--- a/analyzer/config/docker/docker_test.go
+++ b/analyzer/config/docker/docker_test.go
@@ -164,7 +164,7 @@ func Test_dockerConfigAnalyzer_Analyze(t *testing.T) {
 
 			a := docker.NewConfigAnalyzer(nil)
 			ctx := context.Background()
-			got, err := a.Analyze(ctx, analyzer.AnalysisTarget{
+			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: tt.inputFile,
 				Content:  f,
 			})

--- a/analyzer/config/hcl/hcl.go
+++ b/analyzer/config/hcl/hcl.go
@@ -32,24 +32,24 @@ func NewConfigAnalyzer(filePattern *regexp.Regexp) ConfigAnalyzer {
 
 // Analyze analyzes HCL-based config files, defaulting to HCL2.0 spec
 // it returns error only if content does not comply to both HCL2.0 and HCL1.0 spec
-func (a ConfigAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTarget) (*analyzer.AnalysisResult, error) {
-	parsed, err := a.analyze(target)
+func (a ConfigAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
+	parsed, err := a.analyze(input)
 	if err != nil {
-		return nil, xerrors.Errorf("unable to parse HCL (%a): %w", target.FilePath, err)
+		return nil, xerrors.Errorf("unable to parse HCL (%a): %w", input.FilePath, err)
 	}
 
 	return &analyzer.AnalysisResult{
 		Configs: []types.Config{
 			{
 				Type:     types.HCL,
-				FilePath: target.FilePath,
+				FilePath: input.FilePath,
 				Content:  parsed,
 			},
 		},
 	}, nil
 }
 
-func (a ConfigAnalyzer) analyze(target analyzer.AnalysisTarget) (interface{}, error) {
+func (a ConfigAnalyzer) analyze(target analyzer.AnalysisInput) (interface{}, error) {
 	var errs error
 	var parsed interface{}
 

--- a/analyzer/config/hcl/hcl_test.go
+++ b/analyzer/config/hcl/hcl_test.go
@@ -116,7 +116,7 @@ func TestConfigAnalyzer_Analyze(t *testing.T) {
 			a := hcl.NewConfigAnalyzer(nil)
 			require.NoError(t, err)
 			ctx := context.Background()
-			got, err := a.Analyze(ctx, analyzer.AnalysisTarget{
+			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: tt.inputFile,
 				Content:  f,
 			})

--- a/analyzer/config/json/json.go
+++ b/analyzer/config/json/json.go
@@ -30,17 +30,17 @@ func NewConfigAnalyzer(filePattern *regexp.Regexp) ConfigAnalyzer {
 	}
 }
 
-func (a ConfigAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTarget) (*analyzer.AnalysisResult, error) {
+func (a ConfigAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
 	var parsed interface{}
-	if err := json.NewDecoder(target.Content).Decode(&parsed); err != nil {
-		return nil, xerrors.Errorf("unable to decode JSON (%s): %w", target.FilePath, err)
+	if err := json.NewDecoder(input.Content).Decode(&parsed); err != nil {
+		return nil, xerrors.Errorf("unable to decode JSON (%s): %w", input.FilePath, err)
 	}
 
 	return &analyzer.AnalysisResult{
 		Configs: []types.Config{
 			{
 				Type:     types.JSON,
-				FilePath: target.FilePath,
+				FilePath: input.FilePath,
 				Content:  parsed,
 			},
 		},

--- a/analyzer/config/json/json_test.go
+++ b/analyzer/config/json/json_test.go
@@ -135,7 +135,7 @@ func Test_jsonConfigAnalyzer_Analyze(t *testing.T) {
 			s := json.NewConfigAnalyzer(nil)
 
 			ctx := context.Background()
-			got, err := s.Analyze(ctx, analyzer.AnalysisTarget{
+			got, err := s.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: tt.inputFile,
 				Content:  f,
 			})

--- a/analyzer/config/terraform/terraform.go
+++ b/analyzer/config/terraform/terraform.go
@@ -21,12 +21,12 @@ func NewConfigAnalyzer() ConfigAnalyzer {
 }
 
 // Analyze returns a name of Terraform file
-func (a ConfigAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTarget) (*analyzer.AnalysisResult, error) {
+func (a ConfigAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
 	return &analyzer.AnalysisResult{
 		Configs: []types.Config{
 			{
 				Type:     types.Terraform,
-				FilePath: filepath.Join(target.Dir, target.FilePath), // tfsec requires a path from working dir
+				FilePath: filepath.Join(input.Dir, input.FilePath), // tfsec requires a path from working dir
 			},
 		},
 	}, nil

--- a/analyzer/config/terraform/terraform_test.go
+++ b/analyzer/config/terraform/terraform_test.go
@@ -14,13 +14,13 @@ import (
 
 func TestConfigAnalyzer_Analyze(t *testing.T) {
 	tests := []struct {
-		name   string
-		target analyzer.AnalysisTarget
-		want   *analyzer.AnalysisResult
+		name  string
+		input analyzer.AnalysisInput
+		want  *analyzer.AnalysisResult
 	}{
 		{
 			name: "happy path",
-			target: analyzer.AnalysisTarget{
+			input: analyzer.AnalysisInput{
 				Dir:      "path/to/",
 				FilePath: "main.tf",
 			},
@@ -38,7 +38,7 @@ func TestConfigAnalyzer_Analyze(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			a := terraform.ConfigAnalyzer{}
 			ctx := context.Background()
-			got, err := a.Analyze(ctx, tt.target)
+			got, err := a.Analyze(ctx, tt.input)
 
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)

--- a/analyzer/config/toml/toml.go
+++ b/analyzer/config/toml/toml.go
@@ -27,17 +27,17 @@ func NewConfigAnalyzer(filePattern *regexp.Regexp) ConfigAnalyzer {
 	}
 }
 
-func (a ConfigAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTarget) (*analyzer.AnalysisResult, error) {
+func (a ConfigAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
 	var parsed interface{}
-	if _, err := toml.NewDecoder(target.Content).Decode(&parsed); err != nil {
-		return nil, xerrors.Errorf("unable to decode TOML (%s): %w", target.FilePath, err)
+	if _, err := toml.NewDecoder(input.Content).Decode(&parsed); err != nil {
+		return nil, xerrors.Errorf("unable to decode TOML (%s): %w", input.FilePath, err)
 	}
 
 	return &analyzer.AnalysisResult{
 		Configs: []types.Config{
 			{
 				Type:     types.TOML,
-				FilePath: target.FilePath,
+				FilePath: input.FilePath,
 				Content:  parsed,
 			},
 		},

--- a/analyzer/config/toml/toml_test.go
+++ b/analyzer/config/toml/toml_test.go
@@ -96,7 +96,7 @@ func Test_tomlConfigAnalyzer_Analyze(t *testing.T) {
 
 			a := toml.NewConfigAnalyzer(nil)
 			ctx := context.Background()
-			got, err := a.Analyze(ctx, analyzer.AnalysisTarget{
+			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: tt.inputFile,
 				Content:  f,
 			})

--- a/analyzer/config/yaml/yaml.go
+++ b/analyzer/config/yaml/yaml.go
@@ -30,8 +30,8 @@ func NewConfigAnalyzer(filePattern *regexp.Regexp) ConfigAnalyzer {
 	}
 }
 
-func (a ConfigAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTarget) (*analyzer.AnalysisResult, error) {
-	content, err := io.ReadAll(target.Content)
+func (a ConfigAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
+	content, err := io.ReadAll(input.Content)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to read the yaml content: %w", err)
 	}
@@ -46,12 +46,12 @@ func (a ConfigAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTarge
 	for _, doc := range docs {
 		parsed, err := a.parser.Parse(doc)
 		if err != nil {
-			return nil, xerrors.Errorf("unable to parse YAML (%a): %w", target.FilePath, err)
+			return nil, xerrors.Errorf("unable to parse YAML (%a): %w", input.FilePath, err)
 		}
 
 		configs = append(configs, types.Config{
 			Type:     types.YAML,
-			FilePath: target.FilePath,
+			FilePath: input.FilePath,
 			Content:  parsed,
 		})
 	}

--- a/analyzer/config/yaml/yaml_test.go
+++ b/analyzer/config/yaml/yaml_test.go
@@ -219,7 +219,7 @@ func Test_yamlConfigAnalyzer_Analyze(t *testing.T) {
 
 			a := yaml.NewConfigAnalyzer(nil)
 			ctx := context.Background()
-			got, err := a.Analyze(ctx, analyzer.AnalysisTarget{
+			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: tt.inputFile,
 				Content:  f,
 			})

--- a/analyzer/language/dotnet/nuget/nuget.go
+++ b/analyzer/language/dotnet/nuget/nuget.go
@@ -29,16 +29,16 @@ var requiredFiles = []string{lockFile, configFile}
 
 type nugetLibraryAnalyzer struct{}
 
-func (a nugetLibraryAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTarget) (*analyzer.AnalysisResult, error) {
+func (a nugetLibraryAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
 	// Set the default parser
 	parser := lock.Parse
 
-	targetFile := filepath.Base(target.FilePath)
+	targetFile := filepath.Base(input.FilePath)
 	if targetFile == configFile {
 		parser = config.Parse
 	}
 
-	res, err := language.Analyze(types.NuGet, target.FilePath, target.Content, parser)
+	res, err := language.Analyze(types.NuGet, input.FilePath, input.Content, parser)
 	if err != nil {
 		return nil, xerrors.Errorf("NuGet analysis error: %w", err)
 	}

--- a/analyzer/language/dotnet/nuget/nuget_test.go
+++ b/analyzer/language/dotnet/nuget/nuget_test.go
@@ -78,7 +78,7 @@ func Test_nugetibraryAnalyzer_Analyze(t *testing.T) {
 
 			a := nugetLibraryAnalyzer{}
 			ctx := context.Background()
-			got, err := a.Analyze(ctx, analyzer.AnalysisTarget{
+			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: tt.inputFile,
 				Content:  f,
 			})

--- a/analyzer/language/golang/binary/binary.go
+++ b/analyzer/language/golang/binary/binary.go
@@ -21,15 +21,15 @@ const version = 1
 
 type gobinaryLibraryAnalyzer struct{}
 
-func (a gobinaryLibraryAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTarget) (*analyzer.AnalysisResult, error) {
-	libs, err := binary.Parse(target.Content)
+func (a gobinaryLibraryAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
+	libs, err := binary.Parse(input.Content)
 	if errors.Is(err, binary.ErrUnrecognizedExe) || errors.Is(err, binary.ErrNonGoBinary) {
 		return nil, nil
 	} else if err != nil {
 		return nil, xerrors.Errorf("go binary parse error: %w", err)
 	}
 
-	return language.ToAnalysisResult(types.GoBinary, target.FilePath, "", libs), nil
+	return language.ToAnalysisResult(types.GoBinary, input.FilePath, "", libs), nil
 }
 
 func (a gobinaryLibraryAnalyzer) Required(_ string, fileInfo os.FileInfo) bool {

--- a/analyzer/language/golang/binary/binary_test.go
+++ b/analyzer/language/golang/binary/binary_test.go
@@ -54,7 +54,7 @@ func Test_gobinaryLibraryAnalyzer_Analyze(t *testing.T) {
 
 			a := gobinaryLibraryAnalyzer{}
 			ctx := context.Background()
-			got, err := a.Analyze(ctx, analyzer.AnalysisTarget{
+			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: tt.inputFile,
 				Content:  f,
 			})

--- a/analyzer/language/golang/mod/mod.go
+++ b/analyzer/language/golang/mod/mod.go
@@ -24,10 +24,10 @@ var requiredFiles = []string{"go.sum"}
 
 type gomodAnalyzer struct{}
 
-func (a gomodAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTarget) (*analyzer.AnalysisResult, error) {
-	res, err := language.Analyze(types.GoMod, target.FilePath, target.Content, mod.Parse)
+func (a gomodAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
+	res, err := language.Analyze(types.GoMod, input.FilePath, input.Content, mod.Parse)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to analyze %s: %w", target.FilePath, err)
+		return nil, xerrors.Errorf("failed to analyze %s: %w", input.FilePath, err)
 	}
 	return res, nil
 }

--- a/analyzer/language/golang/mod/mod_test.go
+++ b/analyzer/language/golang/mod/mod_test.go
@@ -60,7 +60,7 @@ func Test_gomodAnalyzer_Analyze(t *testing.T) {
 
 			a := gomodAnalyzer{}
 			ctx := context.Background()
-			got, err := a.Analyze(ctx, analyzer.AnalysisTarget{
+			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: tt.inputFile,
 				Content:  f,
 			})

--- a/analyzer/language/java/jar/jar.go
+++ b/analyzer/language/java/jar/jar.go
@@ -26,7 +26,8 @@ var requiredExtensions = []string{".jar", ".war", ".ear"}
 type javaLibraryAnalyzer struct{}
 
 func (a javaLibraryAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
-	libs, err := jar.Parse(input.Content, input.Info.Size(), jar.WithFilePath(input.FilePath))
+	libs, err := jar.Parse(input.Content, input.Info.Size(),
+		jar.WithFilePath(input.FilePath), jar.WithOffline(input.Options.Offline))
 	if err != nil {
 		return nil, xerrors.Errorf("jar/war/ear parse error: %w", err)
 	}

--- a/analyzer/language/java/jar/jar.go
+++ b/analyzer/language/java/jar/jar.go
@@ -25,13 +25,13 @@ var requiredExtensions = []string{".jar", ".war", ".ear"}
 // javaLibraryAnalyzer analyzes jar/war/ear files
 type javaLibraryAnalyzer struct{}
 
-func (a javaLibraryAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTarget) (*analyzer.AnalysisResult, error) {
-	libs, err := jar.Parse(target.Content, target.Info.Size(), jar.WithFilePath(target.FilePath))
+func (a javaLibraryAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
+	libs, err := jar.Parse(input.Content, input.Info.Size(), jar.WithFilePath(input.FilePath))
 	if err != nil {
 		return nil, xerrors.Errorf("jar/war/ear parse error: %w", err)
 	}
 
-	return language.ToAnalysisResult(types.Jar, target.FilePath, target.FilePath, libs), nil
+	return language.ToAnalysisResult(types.Jar, input.FilePath, input.FilePath, libs), nil
 }
 
 func (a javaLibraryAnalyzer) Required(filePath string, _ os.FileInfo) bool {

--- a/analyzer/language/java/jar/jar_test.go
+++ b/analyzer/language/java/jar/jar_test.go
@@ -58,7 +58,7 @@ func Test_javaLibraryAnalyzer_Analyze(t *testing.T) {
 
 			a := javaLibraryAnalyzer{}
 			ctx := context.Background()
-			got, err := a.Analyze(ctx, analyzer.AnalysisTarget{
+			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: tt.inputFile,
 				Info:     stat,
 				Content:  f,

--- a/analyzer/language/java/pom/pom.go
+++ b/analyzer/language/java/pom/pom.go
@@ -21,11 +21,10 @@ const version = 1
 // pomAnalyzer analyzes pom.xml
 type pomAnalyzer struct{}
 
-func (a pomAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTarget) (*analyzer.AnalysisResult, error) {
-	// TODO: support offline mode
-	p := pom.NewParser(target.FilePath)
+func (a pomAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
+	p := pom.NewParser(input.FilePath, pom.WithOffline(input.Options.Offline))
 
-	return language.Analyze(types.Pom, target.FilePath, target.Content, p.Parse)
+	return language.Analyze(types.Pom, input.FilePath, input.Content, p.Parse)
 }
 
 func (a pomAnalyzer) Required(filePath string, _ os.FileInfo) bool {

--- a/analyzer/language/java/pom/pom_test.go
+++ b/analyzer/language/java/pom/pom_test.go
@@ -15,7 +15,6 @@ func Test_pomAnalyzer_Analyze(t *testing.T) {
 	tests := []struct {
 		name      string
 		inputFile string
-		target    analyzer.AnalysisTarget
 		want      *analyzer.AnalysisResult
 		wantErr   string
 	}{
@@ -50,7 +49,7 @@ func Test_pomAnalyzer_Analyze(t *testing.T) {
 			defer f.Close()
 
 			a := pomAnalyzer{}
-			got, err := a.Analyze(nil, analyzer.AnalysisTarget{
+			got, err := a.Analyze(nil, analyzer.AnalysisInput{
 				FilePath: tt.inputFile,
 				Content:  f,
 			})

--- a/analyzer/language/nodejs/npm/npm.go
+++ b/analyzer/language/nodejs/npm/npm.go
@@ -24,7 +24,7 @@ var requiredFiles = []string{"package-lock.json"}
 
 type npmLibraryAnalyzer struct{}
 
-func (a npmLibraryAnalyzer) Analyze(ctx context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
+func (a npmLibraryAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
 	res, err := language.Analyze(types.Npm, input.FilePath, input.Content, npm.Parse)
 	if err != nil {
 		return nil, xerrors.Errorf("unable to parse package-lock.json: %w", err)

--- a/analyzer/language/nodejs/npm/npm.go
+++ b/analyzer/language/nodejs/npm/npm.go
@@ -24,8 +24,8 @@ var requiredFiles = []string{"package-lock.json"}
 
 type npmLibraryAnalyzer struct{}
 
-func (a npmLibraryAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTarget) (*analyzer.AnalysisResult, error) {
-	res, err := language.Analyze(types.Npm, target.FilePath, target.Content, npm.Parse)
+func (a npmLibraryAnalyzer) Analyze(ctx context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
+	res, err := language.Analyze(types.Npm, input.FilePath, input.Content, npm.Parse)
 	if err != nil {
 		return nil, xerrors.Errorf("unable to parse package-lock.json: %w", err)
 	}

--- a/analyzer/language/nodejs/pkg/pkg.go
+++ b/analyzer/language/nodejs/pkg/pkg.go
@@ -24,22 +24,22 @@ const (
 type nodePkgLibraryAnalyzer struct{}
 
 // Analyze analyzes package.json for node packages
-func (a nodePkgLibraryAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTarget) (*analyzer.AnalysisResult, error) {
-	parsedLib, err := packagejson.Parse(target.Content)
+func (a nodePkgLibraryAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
+	parsedLib, err := packagejson.Parse(input.Content)
 	if err != nil {
-		return nil, xerrors.Errorf("unable to parse %s: %w", target.FilePath, err)
+		return nil, xerrors.Errorf("unable to parse %s: %w", input.FilePath, err)
 	}
 	return &analyzer.AnalysisResult{
 		Applications: []types.Application{
 			{
 				Type:     types.NodePkg,
-				FilePath: target.FilePath,
+				FilePath: input.FilePath,
 				Libraries: []types.Package{
 					{
 						Name:     parsedLib.Name,
 						Version:  parsedLib.Version,
 						License:  parsedLib.License,
-						FilePath: target.FilePath,
+						FilePath: input.FilePath,
 					},
 				},
 			},

--- a/analyzer/language/nodejs/pkg/pkg_test.go
+++ b/analyzer/language/nodejs/pkg/pkg_test.go
@@ -13,9 +13,6 @@ import (
 )
 
 func Test_nodePkgLibraryAnalyzer_Analyze(t *testing.T) {
-	type args struct {
-		target analyzer.AnalysisTarget
-	}
 	tests := []struct {
 		name      string
 		inputFile string
@@ -56,7 +53,7 @@ func Test_nodePkgLibraryAnalyzer_Analyze(t *testing.T) {
 
 			a := nodePkgLibraryAnalyzer{}
 			ctx := context.Background()
-			got, err := a.Analyze(ctx, analyzer.AnalysisTarget{
+			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: tt.inputFile,
 				Content:  f,
 			})

--- a/analyzer/language/nodejs/yarn/yarn.go
+++ b/analyzer/language/nodejs/yarn/yarn.go
@@ -24,8 +24,8 @@ var requiredFiles = []string{"yarn.lock"}
 
 type yarnLibraryAnalyzer struct{}
 
-func (a yarnLibraryAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTarget) (*analyzer.AnalysisResult, error) {
-	res, err := language.Analyze(types.Yarn, target.FilePath, target.Content, yarn.Parse)
+func (a yarnLibraryAnalyzer) Analyze(ctx context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
+	res, err := language.Analyze(types.Yarn, input.FilePath, input.Content, yarn.Parse)
 	if err != nil {
 		return nil, xerrors.Errorf("unable to parse yarn.lock: %w", err)
 	}

--- a/analyzer/language/nodejs/yarn/yarn.go
+++ b/analyzer/language/nodejs/yarn/yarn.go
@@ -24,7 +24,7 @@ var requiredFiles = []string{"yarn.lock"}
 
 type yarnLibraryAnalyzer struct{}
 
-func (a yarnLibraryAnalyzer) Analyze(ctx context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
+func (a yarnLibraryAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
 	res, err := language.Analyze(types.Yarn, input.FilePath, input.Content, yarn.Parse)
 	if err != nil {
 		return nil, xerrors.Errorf("unable to parse yarn.lock: %w", err)

--- a/analyzer/language/php/composer/composer.go
+++ b/analyzer/language/php/composer/composer.go
@@ -24,7 +24,7 @@ var requiredFiles = []string{"composer.lock"}
 
 type composerLibraryAnalyzer struct{}
 
-func (a composerLibraryAnalyzer) Analyze(ctx context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
+func (a composerLibraryAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
 	res, err := language.Analyze(types.Composer, input.FilePath, input.Content, composer.Parse)
 	if err != nil {
 		return nil, xerrors.Errorf("error with composer.lock: %w", err)

--- a/analyzer/language/php/composer/composer.go
+++ b/analyzer/language/php/composer/composer.go
@@ -24,8 +24,8 @@ var requiredFiles = []string{"composer.lock"}
 
 type composerLibraryAnalyzer struct{}
 
-func (a composerLibraryAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTarget) (*analyzer.AnalysisResult, error) {
-	res, err := language.Analyze(types.Composer, target.FilePath, target.Content, composer.Parse)
+func (a composerLibraryAnalyzer) Analyze(ctx context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
+	res, err := language.Analyze(types.Composer, input.FilePath, input.Content, composer.Parse)
 	if err != nil {
 		return nil, xerrors.Errorf("error with composer.lock: %w", err)
 	}

--- a/analyzer/language/python/packaging/packaging.go
+++ b/analyzer/language/python/packaging/packaging.go
@@ -41,12 +41,12 @@ var (
 type packagingAnalyzer struct{}
 
 // Analyze analyzes egg and wheel files.
-func (a packagingAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTarget) (*analyzer.AnalysisResult, error) {
-	var r io.Reader = target.Content
+func (a packagingAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
+	var r io.Reader = input.Content
 
 	// .egg file is zip format and PKG-INFO needs to be extracted from the zip file.
-	if strings.HasSuffix(target.FilePath, ".egg") {
-		pkginfoInZip, err := a.analyzeEggZip(target.Content, target.Info.Size())
+	if strings.HasSuffix(input.FilePath, ".egg") {
+		pkginfoInZip, err := a.analyzeEggZip(input.Content, input.Info.Size())
 		if err != nil {
 			return nil, xerrors.Errorf("egg analysis error: %w", err)
 		}
@@ -56,19 +56,19 @@ func (a packagingAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTa
 
 	lib, err := packaging.Parse(r)
 	if err != nil {
-		return nil, xerrors.Errorf("unable to parse %s: %w", target.FilePath, err)
+		return nil, xerrors.Errorf("unable to parse %s: %w", input.FilePath, err)
 	}
 
 	return &analyzer.AnalysisResult{Applications: []types.Application{
 		{
 			Type:     types.PythonPkg,
-			FilePath: target.FilePath,
+			FilePath: input.FilePath,
 			Libraries: []types.Package{
 				{
 					Name:     lib.Name,
 					Version:  lib.Version,
 					License:  lib.License,
-					FilePath: target.FilePath,
+					FilePath: input.FilePath,
 				},
 			},
 		},

--- a/analyzer/language/python/packaging/packaging_test.go
+++ b/analyzer/language/python/packaging/packaging_test.go
@@ -109,7 +109,7 @@ func Test_packagingAnalyzer_Analyze(t *testing.T) {
 
 			a := packagingAnalyzer{}
 			ctx := context.Background()
-			got, err := a.Analyze(ctx, analyzer.AnalysisTarget{
+			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: tt.inputFile,
 				Info:     stat,
 				Content:  f,

--- a/analyzer/language/python/pip/pip.go
+++ b/analyzer/language/python/pip/pip.go
@@ -22,8 +22,8 @@ var requiredFile = "requirements.txt"
 
 type pipLibraryAnalyzer struct{}
 
-func (a pipLibraryAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTarget) (*analyzer.AnalysisResult, error) {
-	res, err := language.Analyze(types.Pip, target.FilePath, target.Content, pip.Parse)
+func (a pipLibraryAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
+	res, err := language.Analyze(types.Pip, input.FilePath, input.Content, pip.Parse)
 	if err != nil {
 		return nil, xerrors.Errorf("unable to parse requirements.txt: %w", err)
 	}

--- a/analyzer/language/python/pip/pip_test.go
+++ b/analyzer/language/python/pip/pip_test.go
@@ -58,7 +58,7 @@ func Test_pipAnalyzer_Analyze(t *testing.T) {
 
 			a := pipLibraryAnalyzer{}
 			ctx := context.Background()
-			got, err := a.Analyze(ctx, analyzer.AnalysisTarget{
+			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: tt.inputFile,
 				Content:  f,
 			})

--- a/analyzer/language/python/pipenv/pipenv.go
+++ b/analyzer/language/python/pipenv/pipenv.go
@@ -24,8 +24,8 @@ var requiredFiles = []string{"Pipfile.lock"}
 
 type pipenvLibraryAnalyzer struct{}
 
-func (a pipenvLibraryAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTarget) (*analyzer.AnalysisResult, error) {
-	res, err := language.Analyze(types.Pipenv, target.FilePath, target.Content, pipenv.Parse)
+func (a pipenvLibraryAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
+	res, err := language.Analyze(types.Pipenv, input.FilePath, input.Content, pipenv.Parse)
 	if err != nil {
 		return nil, xerrors.Errorf("unable to parse Pipfile.lock: %w", err)
 	}

--- a/analyzer/language/python/poetry/poetry.go
+++ b/analyzer/language/python/poetry/poetry.go
@@ -24,8 +24,8 @@ var requiredFiles = []string{"poetry.lock"}
 
 type poetryLibraryAnalyzer struct{}
 
-func (a poetryLibraryAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTarget) (*analyzer.AnalysisResult, error) {
-	res, err := language.Analyze(types.Poetry, target.FilePath, target.Content, poetry.Parse)
+func (a poetryLibraryAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
+	res, err := language.Analyze(types.Poetry, input.FilePath, input.Content, poetry.Parse)
 	if err != nil {
 		return nil, xerrors.Errorf("unable to parse poetry.lock: %w", err)
 	}

--- a/analyzer/language/ruby/bundler/bundler.go
+++ b/analyzer/language/ruby/bundler/bundler.go
@@ -26,8 +26,8 @@ var (
 
 type bundlerLibraryAnalyzer struct{}
 
-func (a bundlerLibraryAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTarget) (*analyzer.AnalysisResult, error) {
-	res, err := language.Analyze(types.Bundler, target.FilePath, target.Content, bundler.Parse)
+func (a bundlerLibraryAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
+	res, err := language.Analyze(types.Bundler, input.FilePath, input.Content, bundler.Parse)
 	if err != nil {
 		return nil, xerrors.Errorf("unable to parse Gemfile.lock: %w", err)
 	}

--- a/analyzer/language/ruby/gemspec/gemspec.go
+++ b/analyzer/language/ruby/gemspec/gemspec.go
@@ -23,23 +23,23 @@ var fileRegex = regexp.MustCompile(`.*/specifications/.+\.gemspec`)
 
 type gemspecLibraryAnalyzer struct{}
 
-func (a gemspecLibraryAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTarget) (*analyzer.AnalysisResult, error) {
-	parsedLib, err := gemspec.Parse(target.Content)
+func (a gemspecLibraryAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
+	parsedLib, err := gemspec.Parse(input.Content)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse %s: %w", target.FilePath, err)
+		return nil, xerrors.Errorf("failed to parse %s: %w", input.FilePath, err)
 	}
 
 	return &analyzer.AnalysisResult{
 		Applications: []types.Application{
 			{
 				Type:     types.GemSpec,
-				FilePath: target.FilePath,
+				FilePath: input.FilePath,
 				Libraries: []types.Package{
 					{
 						Name:     parsedLib.Name,
 						Version:  parsedLib.Version,
 						License:  parsedLib.License,
-						FilePath: target.FilePath,
+						FilePath: input.FilePath,
 					},
 				},
 			},

--- a/analyzer/language/ruby/gemspec/gemspec_test.go
+++ b/analyzer/language/ruby/gemspec/gemspec_test.go
@@ -53,7 +53,7 @@ func Test_gemspecLibraryAnalyzer_Analyze(t *testing.T) {
 
 			a := gemspecLibraryAnalyzer{}
 			ctx := context.Background()
-			got, err := a.Analyze(ctx, analyzer.AnalysisTarget{
+			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: tt.inputFile,
 				Content:  f,
 			})

--- a/analyzer/language/rust/cargo/cargo.go
+++ b/analyzer/language/rust/cargo/cargo.go
@@ -24,8 +24,8 @@ var requiredFiles = []string{"Cargo.lock"}
 
 type cargoLibraryAnalyzer struct{}
 
-func (a cargoLibraryAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTarget) (*analyzer.AnalysisResult, error) {
-	res, err := language.Analyze(types.Cargo, target.FilePath, target.Content, cargo.Parse)
+func (a cargoLibraryAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
+	res, err := language.Analyze(types.Cargo, input.FilePath, input.Content, cargo.Parse)
 	if err != nil {
 		return nil, xerrors.Errorf("error with Cargo.lock: %w", err)
 	}

--- a/analyzer/os/alpine/alpine.go
+++ b/analyzer/os/alpine/alpine.go
@@ -23,8 +23,8 @@ var requiredFiles = []string{"etc/alpine-release"}
 
 type alpineOSAnalyzer struct{}
 
-func (a alpineOSAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTarget) (*analyzer.AnalysisResult, error) {
-	scanner := bufio.NewScanner(target.Content)
+func (a alpineOSAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
+	scanner := bufio.NewScanner(input.Content)
 	for scanner.Scan() {
 		line := scanner.Text()
 		return &analyzer.AnalysisResult{

--- a/analyzer/os/amazonlinux/amazonlinux.go
+++ b/analyzer/os/amazonlinux/amazonlinux.go
@@ -29,8 +29,8 @@ var requiredFiles = []string{"etc/system-release"}
 
 type amazonlinuxOSAnalyzer struct{}
 
-func (a amazonlinuxOSAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTarget) (*analyzer.AnalysisResult, error) {
-	foundOS, err := a.parseRelease(target.Content)
+func (a amazonlinuxOSAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
+	foundOS, err := a.parseRelease(input.Content)
 	if err != nil {
 		return nil, err
 	}

--- a/analyzer/os/amazonlinux/amazonlinux_test.go
+++ b/analyzer/os/amazonlinux/amazonlinux_test.go
@@ -17,13 +17,13 @@ import (
 func Test_amazonlinuxOSAnalyzer_Analyze(t *testing.T) {
 	tests := []struct {
 		name    string
-		target  analyzer.AnalysisTarget
+		input   analyzer.AnalysisInput
 		want    *analyzer.AnalysisResult
 		wantErr string
 	}{
 		{
 			name: "happy path amazon linux 1",
-			target: analyzer.AnalysisTarget{
+			input: analyzer.AnalysisInput{
 				FilePath: "etc/system-release",
 				Content:  strings.NewReader(`Amazon Linux AMI release 2018.03`),
 			},
@@ -36,7 +36,7 @@ func Test_amazonlinuxOSAnalyzer_Analyze(t *testing.T) {
 		},
 		{
 			name: "happy path amazon linux 2",
-			target: analyzer.AnalysisTarget{
+			input: analyzer.AnalysisInput{
 				FilePath: "etc/system-release",
 				Content:  strings.NewReader(`Amazon Linux release 2 (Karoo)`),
 			},
@@ -49,7 +49,7 @@ func Test_amazonlinuxOSAnalyzer_Analyze(t *testing.T) {
 		},
 		{
 			name: "sad path amazon linux 2 without code name",
-			target: analyzer.AnalysisTarget{
+			input: analyzer.AnalysisInput{
 				FilePath: "etc/system-release",
 				Content:  strings.NewReader(`Amazon Linux release 2`),
 			},
@@ -57,7 +57,7 @@ func Test_amazonlinuxOSAnalyzer_Analyze(t *testing.T) {
 		},
 		{
 			name: "sad path",
-			target: analyzer.AnalysisTarget{
+			input: analyzer.AnalysisInput{
 				FilePath: "etc/system-release",
 				Content:  strings.NewReader(`foo bar`),
 			},
@@ -68,7 +68,7 @@ func Test_amazonlinuxOSAnalyzer_Analyze(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			a := amazonlinuxOSAnalyzer{}
 			ctx := context.Background()
-			got, err := a.Analyze(ctx, tt.target)
+			got, err := a.Analyze(ctx, tt.input)
 			if tt.wantErr != "" {
 				require.NotNil(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)

--- a/analyzer/os/debian/debian.go
+++ b/analyzer/os/debian/debian.go
@@ -23,8 +23,8 @@ var requiredFiles = []string{"etc/debian_version"}
 
 type debianOSAnalyzer struct{}
 
-func (a debianOSAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTarget) (*analyzer.AnalysisResult, error) {
-	scanner := bufio.NewScanner(target.Content)
+func (a debianOSAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
+	scanner := bufio.NewScanner(input.Content)
 	for scanner.Scan() {
 		line := scanner.Text()
 		return &analyzer.AnalysisResult{

--- a/analyzer/os/debian/debian_test.go
+++ b/analyzer/os/debian/debian_test.go
@@ -55,7 +55,7 @@ func Test_debianOSAnalyzer_Analyze(t *testing.T) {
 
 			ctx := context.Background()
 
-			got, err := a.Analyze(ctx, analyzer.AnalysisTarget{
+			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: "etc/debian_version",
 				Content:  f,
 			})

--- a/analyzer/os/photon/photon.go
+++ b/analyzer/os/photon/photon.go
@@ -30,9 +30,9 @@ var requiredFiles = []string{
 
 type photonOSAnalyzer struct{}
 
-func (a photonOSAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTarget) (*analyzer.AnalysisResult, error) {
+func (a photonOSAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
 	photonName := ""
-	scanner := bufio.NewScanner(target.Content)
+	scanner := bufio.NewScanner(input.Content)
 	for scanner.Scan() {
 		line := scanner.Text()
 		if strings.HasPrefix(line, "NAME=\"VMware Photon") {

--- a/analyzer/os/photon/photon_test.go
+++ b/analyzer/os/photon/photon_test.go
@@ -44,7 +44,7 @@ func Test_photonOSAnalyzer_Analyze(t *testing.T) {
 			defer f.Close()
 
 			ctx := context.Background()
-			got, err := a.Analyze(ctx, analyzer.AnalysisTarget{
+			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: "etc/os-release",
 				Content:  f,
 			})

--- a/analyzer/os/redhatbase/alma.go
+++ b/analyzer/os/redhatbase/alma.go
@@ -22,8 +22,8 @@ func init() {
 
 type almaOSAnalyzer struct{}
 
-func (a almaOSAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTarget) (*analyzer.AnalysisResult, error) {
-	scanner := bufio.NewScanner(target.Content)
+func (a almaOSAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
+	scanner := bufio.NewScanner(input.Content)
 	for scanner.Scan() {
 		line := scanner.Text()
 		result := redhatRe.FindStringSubmatch(strings.TrimSpace(line))

--- a/analyzer/os/redhatbase/alma_test.go
+++ b/analyzer/os/redhatbase/alma_test.go
@@ -40,7 +40,7 @@ func Test_almaOSAnalyzer_Analyze(t *testing.T) {
 
 			ctx := context.Background()
 
-			got, err := a.Analyze(ctx, analyzer.AnalysisTarget{
+			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: "etc/almalinux-release",
 				Content:  f,
 			})

--- a/analyzer/os/redhatbase/centos.go
+++ b/analyzer/os/redhatbase/centos.go
@@ -22,8 +22,8 @@ func init() {
 
 type centOSAnalyzer struct{}
 
-func (a centOSAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTarget) (*analyzer.AnalysisResult, error) {
-	scanner := bufio.NewScanner(target.Content)
+func (a centOSAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
+	scanner := bufio.NewScanner(input.Content)
 	for scanner.Scan() {
 		line := scanner.Text()
 		result := redhatRe.FindStringSubmatch(strings.TrimSpace(line))

--- a/analyzer/os/redhatbase/centos_test.go
+++ b/analyzer/os/redhatbase/centos_test.go
@@ -40,7 +40,7 @@ func Test_centosOSAnalyzer_Analyze(t *testing.T) {
 			require.NoError(t, err)
 			ctx := context.Background()
 
-			got, err := a.Analyze(ctx, analyzer.AnalysisTarget{
+			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: "etc/centos-release",
 				Content:  f,
 			})

--- a/analyzer/os/redhatbase/fedora.go
+++ b/analyzer/os/redhatbase/fedora.go
@@ -22,8 +22,8 @@ func init() {
 
 type fedoraOSAnalyzer struct{}
 
-func (a fedoraOSAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTarget) (*analyzer.AnalysisResult, error) {
-	scanner := bufio.NewScanner(target.Content)
+func (a fedoraOSAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
+	scanner := bufio.NewScanner(input.Content)
 	for scanner.Scan() {
 		line := scanner.Text()
 		result := redhatRe.FindStringSubmatch(strings.TrimSpace(line))

--- a/analyzer/os/redhatbase/fedora_test.go
+++ b/analyzer/os/redhatbase/fedora_test.go
@@ -39,7 +39,7 @@ func Test_fedoraOSAnalyzer_Analyze(t *testing.T) {
 			defer f.Close()
 
 			ctx := context.Background()
-			got, err := a.Analyze(ctx, analyzer.AnalysisTarget{
+			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: "etc/fedora-release",
 				Content:  f,
 			})

--- a/analyzer/os/redhatbase/oracle.go
+++ b/analyzer/os/redhatbase/oracle.go
@@ -23,8 +23,8 @@ func init() {
 
 type oracleOSAnalyzer struct{}
 
-func (a oracleOSAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTarget) (*analyzer.AnalysisResult, error) {
-	scanner := bufio.NewScanner(target.Content)
+func (a oracleOSAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
+	scanner := bufio.NewScanner(input.Content)
 	for scanner.Scan() {
 		line := scanner.Text()
 		result := redhatRe.FindStringSubmatch(strings.TrimSpace(line))

--- a/analyzer/os/redhatbase/oracle_test.go
+++ b/analyzer/os/redhatbase/oracle_test.go
@@ -39,7 +39,7 @@ func Test_oracleOSAnalyzer_Analyze(t *testing.T) {
 			defer f.Close()
 
 			ctx := context.Background()
-			got, err := a.Analyze(ctx, analyzer.AnalysisTarget{
+			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: "etc/oracle-release",
 				Content:  f,
 			})

--- a/analyzer/os/redhatbase/redhatbase.go
+++ b/analyzer/os/redhatbase/redhatbase.go
@@ -29,8 +29,8 @@ var redhatRe = regexp.MustCompile(`(.*) release (\d[\d\.]*)`)
 
 type redhatOSAnalyzer struct{}
 
-func (a redhatOSAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTarget) (*analyzer.AnalysisResult, error) {
-	foundOS, err := a.parseRelease(target.Content)
+func (a redhatOSAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
+	foundOS, err := a.parseRelease(input.Content)
 	if err != nil {
 		return nil, err
 	}

--- a/analyzer/os/redhatbase/redhatbase_test.go
+++ b/analyzer/os/redhatbase/redhatbase_test.go
@@ -39,7 +39,7 @@ func Test_redhatOSAnalyzer_Analyze(t *testing.T) {
 			defer f.Close()
 
 			ctx := context.Background()
-			got, err := a.Analyze(ctx, analyzer.AnalysisTarget{
+			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: "etc/redhat-release",
 				Content:  f,
 			})

--- a/analyzer/os/redhatbase/rocky.go
+++ b/analyzer/os/redhatbase/rocky.go
@@ -22,8 +22,8 @@ func init() {
 
 type rockyOSAnalyzer struct{}
 
-func (a rockyOSAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTarget) (*analyzer.AnalysisResult, error) {
-	scanner := bufio.NewScanner(target.Content)
+func (a rockyOSAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
+	scanner := bufio.NewScanner(input.Content)
 	for scanner.Scan() {
 		line := scanner.Text()
 		result := redhatRe.FindStringSubmatch(strings.TrimSpace(line))

--- a/analyzer/os/redhatbase/rocky_test.go
+++ b/analyzer/os/redhatbase/rocky_test.go
@@ -39,7 +39,7 @@ func Test_rockyOSAnalyzer_Analyze(t *testing.T) {
 			defer f.Close()
 
 			ctx := context.Background()
-			got, err := a.Analyze(ctx, analyzer.AnalysisTarget{
+			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: "etc/rocky-release",
 				Content:  f,
 			})

--- a/analyzer/os/suse/suse.go
+++ b/analyzer/os/suse/suse.go
@@ -27,9 +27,9 @@ var requiredFiles = []string{
 
 type suseOSAnalyzer struct{}
 
-func (a suseOSAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTarget) (*analyzer.AnalysisResult, error) {
+func (a suseOSAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
 	suseName := ""
-	scanner := bufio.NewScanner(target.Content)
+	scanner := bufio.NewScanner(input.Content)
 	for scanner.Scan() {
 		line := scanner.Text()
 		if strings.HasPrefix(line, "NAME=\"openSUSE") {

--- a/analyzer/os/suse/suse_test.go
+++ b/analyzer/os/suse/suse_test.go
@@ -55,7 +55,7 @@ func Test_suseOSAnalyzer_Analyze(t *testing.T) {
 			defer f.Close()
 
 			ctx := context.Background()
-			got, err := a.Analyze(ctx, analyzer.AnalysisTarget{
+			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: "etc/lsb-release",
 				Content:  f,
 			})

--- a/analyzer/os/ubuntu/ubuntu.go
+++ b/analyzer/os/ubuntu/ubuntu.go
@@ -24,9 +24,9 @@ var requiredFiles = []string{"etc/lsb-release"}
 
 type ubuntuOSAnalyzer struct{}
 
-func (a ubuntuOSAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTarget) (*analyzer.AnalysisResult, error) {
+func (a ubuntuOSAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
 	isUbuntu := false
-	scanner := bufio.NewScanner(target.Content)
+	scanner := bufio.NewScanner(input.Content)
 	for scanner.Scan() {
 		line := scanner.Text()
 		if line == "DISTRIB_ID=Ubuntu" {

--- a/analyzer/os/ubuntu/ubuntu_test.go
+++ b/analyzer/os/ubuntu/ubuntu_test.go
@@ -40,7 +40,7 @@ func Test_ubuntuOSAnalyzer_Analyze(t *testing.T) {
 			defer f.Close()
 
 			ctx := context.Background()
-			got, err := a.Analyze(ctx, analyzer.AnalysisTarget{
+			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: "etc/lsb-release",
 				Content:  f,
 			})

--- a/analyzer/pkg/apk/apk.go
+++ b/analyzer/pkg/apk/apk.go
@@ -24,14 +24,14 @@ var requiredFiles = []string{"lib/apk/db/installed"}
 
 type alpinePkgAnalyzer struct{}
 
-func (a alpinePkgAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTarget) (*analyzer.AnalysisResult, error) {
-	scanner := bufio.NewScanner(target.Content)
+func (a alpinePkgAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
+	scanner := bufio.NewScanner(input.Content)
 	parsedPkgs, installedFiles := a.parseApkInfo(scanner)
 
 	return &analyzer.AnalysisResult{
 		PackageInfos: []types.PackageInfo{
 			{
-				FilePath: target.FilePath,
+				FilePath: input.FilePath,
 				Packages: parsedPkgs,
 			},
 		},

--- a/analyzer/pkg/dpkg/dpkg.go
+++ b/analyzer/pkg/dpkg/dpkg.go
@@ -35,13 +35,13 @@ var (
 
 type dpkgAnalyzer struct{}
 
-func (a dpkgAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTarget) (*analyzer.AnalysisResult, error) {
-	scanner := bufio.NewScanner(target.Content)
-	if a.isListFile(filepath.Split(target.FilePath)) {
+func (a dpkgAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
+	scanner := bufio.NewScanner(input.Content)
+	if a.isListFile(filepath.Split(input.FilePath)) {
 		return a.parseDpkgInfoList(scanner)
 	}
 
-	return a.parseDpkgStatus(target.FilePath, scanner)
+	return a.parseDpkgStatus(input.FilePath, scanner)
 }
 
 // parseDpkgStatus parses /var/lib/dpkg/info/*.list

--- a/analyzer/pkg/dpkg/dpkg_test.go
+++ b/analyzer/pkg/dpkg/dpkg_test.go
@@ -191,7 +191,7 @@ func Test_dpkgAnalyzer_Analyze(t *testing.T) {
 
 			a := dpkgAnalyzer{}
 			ctx := context.Background()
-			got, err := a.Analyze(ctx, analyzer.AnalysisTarget{
+			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: tt.filePath,
 				Content:  f,
 			})

--- a/analyzer/pkg/rpm/rpm.go
+++ b/analyzer/pkg/rpm/rpm.go
@@ -32,8 +32,8 @@ var errUnexpectedNameFormat = xerrors.New("unexpected name format")
 
 type rpmPkgAnalyzer struct{}
 
-func (a rpmPkgAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTarget) (*analyzer.AnalysisResult, error) {
-	parsedPkgs, installedFiles, err := a.parsePkgInfo(target.Content)
+func (a rpmPkgAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
+	parsedPkgs, installedFiles, err := a.parsePkgInfo(input.Content)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to parse rpmdb: %w", err)
 	}
@@ -41,7 +41,7 @@ func (a rpmPkgAnalyzer) Analyze(_ context.Context, target analyzer.AnalysisTarge
 	return &analyzer.AnalysisResult{
 		PackageInfos: []types.PackageInfo{
 			{
-				FilePath: target.FilePath,
+				FilePath: input.FilePath,
 				Packages: parsedPkgs,
 			},
 		},

--- a/artifact/artifact.go
+++ b/artifact/artifact.go
@@ -15,6 +15,7 @@ type Option struct {
 	SkipFiles         []string
 	SkipDirs          []string
 	Quiet             bool
+	Offline           bool
 }
 
 func (o *Option) Sort() {

--- a/artifact/image/image.go
+++ b/artifact/image/image.go
@@ -200,7 +200,8 @@ func (a Artifact) inspectLayer(ctx context.Context, diffID string) (types.BlobIn
 	limit := semaphore.NewWeighted(parallel)
 
 	opqDirs, whFiles, err := a.walker.Walk(r, func(filePath string, info os.FileInfo, opener analyzer.Opener) error {
-		if err = a.analyzer.AnalyzeFile(ctx, &wg, limit, result, "", filePath, info, opener); err != nil {
+		opts := analyzer.AnalysisOptions{Offline: a.artifactOption.Offline}
+		if err = a.analyzer.AnalyzeFile(ctx, &wg, limit, result, "", filePath, info, opener, opts); err != nil {
 			return xerrors.Errorf("failed to analyze %s: %w", filePath, err)
 		}
 		return nil

--- a/artifact/local/fs.go
+++ b/artifact/local/fs.go
@@ -87,7 +87,9 @@ func (a Artifact) Inspect(ctx context.Context) (types.ArtifactReference, error) 
 		if err != nil {
 			return xerrors.Errorf("filepath rel (%s): %w", filePath, err)
 		}
-		if err = a.analyzer.AnalyzeFile(ctx, &wg, limit, result, a.dir, filePath, info, opener); err != nil {
+
+		opts := analyzer.AnalysisOptions{Offline: a.artifactOption.Offline}
+		if err = a.analyzer.AnalyzeFile(ctx, &wg, limit, result, a.dir, filePath, info, opener, opts); err != nil {
 			return xerrors.Errorf("analyze file (%s): %w", filePath, err)
 		}
 		return nil

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/alicebob/miniredis/v2 v2.16.0
 	github.com/aquasecurity/cfsec v0.2.2
 	github.com/aquasecurity/defsec v0.0.37
-	github.com/aquasecurity/go-dep-parser v0.0.0-20211223204250-4041fbb3fb36
+	github.com/aquasecurity/go-dep-parser v0.0.0-20211224061556-d0e33761a8ab
 	github.com/aquasecurity/testdocker v0.0.0-20210911155206-e1e85f5a1516
 	github.com/aquasecurity/tfsec v0.63.1
 	github.com/aws/aws-sdk-go v1.42.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/alicebob/miniredis/v2 v2.16.0
 	github.com/aquasecurity/cfsec v0.2.2
 	github.com/aquasecurity/defsec v0.0.37
-	github.com/aquasecurity/go-dep-parser v0.0.0-20211223152202-b497b40cd9d2
+	github.com/aquasecurity/go-dep-parser v0.0.0-20211223204250-4041fbb3fb36
 	github.com/aquasecurity/testdocker v0.0.0-20210911155206-e1e85f5a1516
 	github.com/aquasecurity/tfsec v0.63.1
 	github.com/aws/aws-sdk-go v1.42.0

--- a/go.sum
+++ b/go.sum
@@ -196,8 +196,8 @@ github.com/aquasecurity/cfsec v0.2.2 h1:hq6MZlg7XFZsrerCv297N4HRlnJM7K6LLd/l/xCz
 github.com/aquasecurity/cfsec v0.2.2/go.mod h1:sUELRJqIPXTOZiHUx7TzyyFFzuk0W22IG6IWAoV8T6U=
 github.com/aquasecurity/defsec v0.0.37 h1:zdZndlKrW257b8VLK1UwfmXiyPuDrNA+wzBilHRk1LA=
 github.com/aquasecurity/defsec v0.0.37/go.mod h1:csaBEcJ3AKy44expnW0dCANEZcS/c1vcJjwBCbnKWBM=
-github.com/aquasecurity/go-dep-parser v0.0.0-20211223204250-4041fbb3fb36 h1:4Qi/CveMZGBXj/K0fjo9bF7D0ZAOblf/Rj35SMmu8v4=
-github.com/aquasecurity/go-dep-parser v0.0.0-20211223204250-4041fbb3fb36/go.mod h1:mYbm6nW+oy1o7gGYngbki6y2VPUf6BPt5U7+O9C78sI=
+github.com/aquasecurity/go-dep-parser v0.0.0-20211224061556-d0e33761a8ab h1:/i0NsV3rYRcW0hkcCCrHmppX5rAr3rlWVIGKdeKBThU=
+github.com/aquasecurity/go-dep-parser v0.0.0-20211224061556-d0e33761a8ab/go.mod h1:mYbm6nW+oy1o7gGYngbki6y2VPUf6BPt5U7+O9C78sI=
 github.com/aquasecurity/testdocker v0.0.0-20210911155206-e1e85f5a1516 h1:moQmzbpLo5dxHQCyEhqzizsDSNrNhn/7uRTCZzo4A1o=
 github.com/aquasecurity/testdocker v0.0.0-20210911155206-e1e85f5a1516/go.mod h1:gTd97VdQ0rg8Mkiic3rPgNOQdprZ7feTAhiD5mGQjgM=
 github.com/aquasecurity/tfsec v0.63.1 h1:KH63HTcUoab7d3PKtqFO6T8K5AY7bzLw7Kiu+EY9U64=

--- a/go.sum
+++ b/go.sum
@@ -196,8 +196,8 @@ github.com/aquasecurity/cfsec v0.2.2 h1:hq6MZlg7XFZsrerCv297N4HRlnJM7K6LLd/l/xCz
 github.com/aquasecurity/cfsec v0.2.2/go.mod h1:sUELRJqIPXTOZiHUx7TzyyFFzuk0W22IG6IWAoV8T6U=
 github.com/aquasecurity/defsec v0.0.37 h1:zdZndlKrW257b8VLK1UwfmXiyPuDrNA+wzBilHRk1LA=
 github.com/aquasecurity/defsec v0.0.37/go.mod h1:csaBEcJ3AKy44expnW0dCANEZcS/c1vcJjwBCbnKWBM=
-github.com/aquasecurity/go-dep-parser v0.0.0-20211223152202-b497b40cd9d2 h1:B+lL7tKxen+aWygRCv5YRjwq08YokAEHMrTsrujURrc=
-github.com/aquasecurity/go-dep-parser v0.0.0-20211223152202-b497b40cd9d2/go.mod h1:mYbm6nW+oy1o7gGYngbki6y2VPUf6BPt5U7+O9C78sI=
+github.com/aquasecurity/go-dep-parser v0.0.0-20211223204250-4041fbb3fb36 h1:4Qi/CveMZGBXj/K0fjo9bF7D0ZAOblf/Rj35SMmu8v4=
+github.com/aquasecurity/go-dep-parser v0.0.0-20211223204250-4041fbb3fb36/go.mod h1:mYbm6nW+oy1o7gGYngbki6y2VPUf6BPt5U7+O9C78sI=
 github.com/aquasecurity/testdocker v0.0.0-20210911155206-e1e85f5a1516 h1:moQmzbpLo5dxHQCyEhqzizsDSNrNhn/7uRTCZzo4A1o=
 github.com/aquasecurity/testdocker v0.0.0-20210911155206-e1e85f5a1516/go.mod h1:gTd97VdQ0rg8Mkiic3rPgNOQdprZ7feTAhiD5mGQjgM=
 github.com/aquasecurity/tfsec v0.63.1 h1:KH63HTcUoab7d3PKtqFO6T8K5AY7bzLw7Kiu+EY9U64=


### PR DESCRIPTION
## Description
This option allows avoiding Internet access. The results with/without the option may differ. For example, the offline mode will not try to resolve transitive dependencies in pom.xml when the dependency doesn't exist in the local repositories. On the other hand, the online mode will resolve those dependencies in the remote repositories. It means the dependencies might be less in offline mode.

## Supported Analyzers
- Java
  - [x] pom.xml
  - [x] JAR

## Blockers
- [x] https://github.com/aquasecurity/go-dep-parser/pull/18
- [x] https://github.com/aquasecurity/go-dep-parser/pull/70