### PR TITLE
Allow more filenames for the PIP requirements files

### DIFF
--- a/analyzer/language/python/pip/pip.go
+++ b/analyzer/language/python/pip/pip.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"regexp"
 
 	"github.com/aquasecurity/fanal/analyzer"
 	"github.com/aquasecurity/fanal/analyzer/language"
@@ -18,7 +19,7 @@ func init() {
 
 const version = 1
 
-var requiredFile = "requirements.txt"
+var fileRegex = regexp.MustCompile(`^requirements(-.*)?\.txt$`)
 
 type pipLibraryAnalyzer struct{}
 
@@ -32,7 +33,7 @@ func (a pipLibraryAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisIn
 
 func (a pipLibraryAnalyzer) Required(filePath string, _ os.FileInfo) bool {
 	fileName := filepath.Base(filePath)
-	return fileName == requiredFile
+	return fileRegex.MatchString(fileName)
 }
 
 func (a pipLibraryAnalyzer) Type() analyzer.Type {

--- a/analyzer/language/python/pip/pip_test.go
+++ b/analyzer/language/python/pip/pip_test.go
@@ -86,8 +86,18 @@ func Test_pipAnalyzer_Required(t *testing.T) {
 			want:     true,
 		},
 		{
+			name:     "happy",
+			filePath: "test/requirements-dev.txt",
+			want:     true,
+		},
+		{
 			name:     "sad",
 			filePath: "a/b/c/d/test.sum",
+			want:     false,
+		},
+		{
+			name:     "sad",
+			filePath: "test/requirementstest.txt",
 			want:     false,
 		},
 	}


### PR DESCRIPTION
This PR extends the python/pip analyzer to allow more flexible filenames.
It's quite common to split up the requirements.txt file into multiple files like requirements-dev.txt and requirements-prod.txt.

Dependabot also looks for files like this.