### PR TITLE
fix(rpm): do not ignore installed files via third-party rpm

### DIFF
--- a/analyzer/pkg/rpm/rpm.go
+++ b/analyzer/pkg/rpm/rpm.go
@@ -30,7 +30,18 @@ var requiredFiles = []string{
 }
 var errUnexpectedNameFormat = xerrors.New("unexpected name format")
 
-var osVendors = []string{"Amazon Linux", "Amazon.com", "CentOS", "Fedora Project", "Oracle America", "Red Hat, Inc.", "AlmaLinux", "CloudLinux"}
+var osVendors = []string{
+	"Amazon Linux",     // Amazon Linux 1
+	"Amazon.com",       // Amazon Linux 2
+	"CentOS",           // CentOS
+	"Fedora Project",   // Fedora
+	"Oracle America",   // Oracle Linux
+	"Red Hat, Inc.",    // Red Hat
+	"AlmaLinux",        // AlmaLinux
+	"CloudLinux",       // AlmaLinux
+	"VMware",           // Photon
+	"openSUSE Project", // OpenSUSE
+}
 
 type rpmPkgAnalyzer struct{}
 
@@ -108,7 +119,7 @@ func (a rpmPkgAnalyzer) parsePkgInfo(rc io.Reader) ([]types.Package, []string, e
 
 		//check if the package is preinstalled on the system
 		var files []string
-		if utils.StringInSlice(pkg.Vendor, defaultOsVendors) {
+		if utils.StringInSlice(pkg.Vendor, osVendors) {
 			files, err = pkg.InstalledFiles()
 			if err != nil {
 				return nil, nil, xerrors.Errorf("unable to get installed files: %w", err)

--- a/analyzer/pkg/rpm/rpm.go
+++ b/analyzer/pkg/rpm/rpm.go
@@ -191,7 +191,7 @@ func (a rpmPkgAnalyzer) Version() int {
 
 func packageProvidedByVendor(pkgVendor string) bool {
 	for _, vendor := range osVendors {
-		if strings.Contains(pkgVendor, vendor) {
+		if strings.HasPrefix(pkgVendor, vendor) {
 			return true
 		}
 	}

--- a/analyzer/pkg/rpm/rpm.go
+++ b/analyzer/pkg/rpm/rpm.go
@@ -30,7 +30,7 @@ var requiredFiles = []string{
 }
 var errUnexpectedNameFormat = xerrors.New("unexpected name format")
 
-var defaultOsVendors = []string{"Amazon Linux", "Amazon.com", "CentOS", "Fedora Project", "Oracle America", "Red Hat, Inc.", "AlmaLinux", "CloudLinux"}
+var osVendors = []string{"Amazon Linux", "Amazon.com", "CentOS", "Fedora Project", "Oracle America", "Red Hat, Inc.", "AlmaLinux", "CloudLinux"}
 
 type rpmPkgAnalyzer struct{}
 

--- a/analyzer/pkg/rpm/rpm.go
+++ b/analyzer/pkg/rpm/rpm.go
@@ -39,7 +39,7 @@ var osVendors = []string{
 	"Red Hat",  // Red Hat
 	"AlmaLinux",      // AlmaLinux
 	"CloudLinux",     // AlmaLinux
-	"VMware, Inc.",   // Photon OS
+	"VMware",   // Photon OS
 	"SUSE",           // openSUSE
 }
 

--- a/analyzer/pkg/rpm/rpm.go
+++ b/analyzer/pkg/rpm/rpm.go
@@ -118,7 +118,8 @@ func (a rpmPkgAnalyzer) parsePkgInfo(rc io.Reader) ([]types.Package, []string, e
 			}
 		}
 
-		// check if the package is vendor-provided
+		// Check if the package is vendor-provided.
+		// If the package is not provided by vendor, the installed files should not be skipped.
 		var files []string
 		if packageProvidedByVendor(pkg.Vendor) {
 			files, err = pkg.InstalledFiles()

--- a/analyzer/pkg/rpm/rpm.go
+++ b/analyzer/pkg/rpm/rpm.go
@@ -40,7 +40,7 @@ var osVendors = []string{
 	"AlmaLinux",      // AlmaLinux
 	"CloudLinux",     // AlmaLinux
 	"VMware, Inc.",   // Photon OS
-	"SUSE",           // OpenSUSE
+	"SUSE",           // openSUSE
 }
 
 type rpmPkgAnalyzer struct{}

--- a/analyzer/pkg/rpm/rpm.go
+++ b/analyzer/pkg/rpm/rpm.go
@@ -117,7 +117,7 @@ func (a rpmPkgAnalyzer) parsePkgInfo(rc io.Reader) ([]types.Package, []string, e
 			}
 		}
 
-		//check if the package is preinstalled on the system
+		// check if the package is vendor-provided
 		var files []string
 		if utils.StringInSlice(pkg.Vendor, osVendors) {
 			files, err = pkg.InstalledFiles()

--- a/analyzer/pkg/rpm/rpm.go
+++ b/analyzer/pkg/rpm/rpm.go
@@ -31,16 +31,16 @@ var requiredFiles = []string{
 var errUnexpectedNameFormat = xerrors.New("unexpected name format")
 
 var osVendors = []string{
-	"Amazon Linux",     // Amazon Linux 1
-	"Amazon.com",       // Amazon Linux 2
-	"CentOS",           // CentOS
-	"Fedora Project",   // Fedora
-	"Oracle America",   // Oracle Linux
-	"Red Hat, Inc.",    // Red Hat
-	"AlmaLinux",        // AlmaLinux
-	"CloudLinux",       // AlmaLinux
-	"VMware",           // Photon
-	"openSUSE Project", // OpenSUSE
+	"Amazon Linux",   // Amazon Linux 1
+	"Amazon.com",     // Amazon Linux 2
+	"CentOS",         // CentOS
+	"Fedora Project", // Fedora
+	"Oracle America", // Oracle Linux
+	"Red Hat, Inc.",  // Red Hat
+	"AlmaLinux",      // AlmaLinux
+	"CloudLinux",     // AlmaLinux
+	"VMware, Inc.",   // Photon OS
+	"SUSE",           // OpenSUSE
 }
 
 type rpmPkgAnalyzer struct{}
@@ -119,7 +119,7 @@ func (a rpmPkgAnalyzer) parsePkgInfo(rc io.Reader) ([]types.Package, []string, e
 
 		// check if the package is vendor-provided
 		var files []string
-		if utils.StringInSlice(pkg.Vendor, osVendors) {
+		if packageProvidedByVendor(pkg.Vendor) {
 			files, err = pkg.InstalledFiles()
 			if err != nil {
 				return nil, nil, xerrors.Errorf("unable to get installed files: %w", err)
@@ -187,4 +187,13 @@ func (a rpmPkgAnalyzer) Type() analyzer.Type {
 
 func (a rpmPkgAnalyzer) Version() int {
 	return version
+}
+
+func packageProvidedByVendor(pkgVendor string) bool {
+	for _, vendor := range osVendors {
+		if strings.Contains(pkgVendor, vendor) {
+			return true
+		}
+	}
+	return false
 }

--- a/analyzer/pkg/rpm/rpm.go
+++ b/analyzer/pkg/rpm/rpm.go
@@ -36,7 +36,7 @@ var osVendors = []string{
 	"CentOS",         // CentOS
 	"Fedora Project", // Fedora
 	"Oracle America", // Oracle Linux
-	"Red Hat, Inc.",  // Red Hat
+	"Red Hat",  // Red Hat
 	"AlmaLinux",      // AlmaLinux
 	"CloudLinux",     // AlmaLinux
 	"VMware, Inc.",   // Photon OS

--- a/analyzer/pkg/rpm/rpm.go
+++ b/analyzer/pkg/rpm/rpm.go
@@ -107,7 +107,7 @@ func (a rpmPkgAnalyzer) parsePkgInfo(rc io.Reader) ([]types.Package, []string, e
 		}
 
 		//check if the package is preinstalled on the system
-		files := []string{}
+		var files []string
 		if utils.StringInSlice(pkg.Vendor, defaultOsVendors) {
 			files, err = pkg.InstalledFiles()
 			if err != nil {

--- a/analyzer/pkg/rpm/rpm.go
+++ b/analyzer/pkg/rpm/rpm.go
@@ -30,6 +30,8 @@ var requiredFiles = []string{
 }
 var errUnexpectedNameFormat = xerrors.New("unexpected name format")
 
+var defaultOsVendors = []string{"Amazon Linux", "Amazon.com", "CentOS", "Fedora Project", "Oracle America", "Red Hat, Inc.", "AlmaLinux", "CloudLinux"}
+
 type rpmPkgAnalyzer struct{}
 
 func (a rpmPkgAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
@@ -104,9 +106,13 @@ func (a rpmPkgAnalyzer) parsePkgInfo(rc io.Reader) ([]types.Package, []string, e
 			}
 		}
 
-		files, err := pkg.InstalledFiles()
-		if err != nil {
-			return nil, nil, xerrors.Errorf("unable to get installed files: %w", err)
+		//check if the package is preinstalled on the system
+		files := []string{}
+		if utils.StringInSlice(pkg.Vendor, defaultOsVendors) {
+			files, err = pkg.InstalledFiles()
+			if err != nil {
+				return nil, nil, xerrors.Errorf("unable to get installed files: %w", err)
+			}
 		}
 
 		p := types.Package{

--- a/analyzer/pkg/rpm/rpm.go
+++ b/analyzer/pkg/rpm/rpm.go
@@ -36,11 +36,12 @@ var osVendors = []string{
 	"CentOS",         // CentOS
 	"Fedora Project", // Fedora
 	"Oracle America", // Oracle Linux
-	"Red Hat",  // Red Hat
+	"Red Hat",        // Red Hat
 	"AlmaLinux",      // AlmaLinux
 	"CloudLinux",     // AlmaLinux
-	"VMware",   // Photon OS
-	"SUSE",           // openSUSE
+	"VMware",         // Photon OS
+	"SUSE",           // SUSE Linux Enterprise
+	"openSUSE",       // openSUSE
 }
 
 type rpmPkgAnalyzer struct{}


### PR DESCRIPTION
## Description
Added checking of rpm packages for being provided by OS vendor. 
## Issues 
- aquasecurity/trivy/issues/1546
- aquasecurity/trivy/issues/1481