### PR TITLE
Extend Dockerfile filename support

### DIFF
--- a/analyzer/config/docker/docker_test.go
+++ b/analyzer/config/docker/docker_test.go
@@ -208,6 +208,11 @@ func Test_dockerConfigAnalyzer_Required(t *testing.T) {
 			want:     true,
 		},
 		{
+			name:     "dockerfile with suffix",
+			filePath: "Dockerfile-build",
+			want:     true,
+		},
+		{
 			name:     "Dockerfile in dir",
 			filePath: "docker/Dockerfile",
 			want:     true,


### PR DESCRIPTION
This PR changes the Dockerfile matching to a regex, documents the allowed fileformats and adds support for filenames like Dockerfile-build.