### PR TITLE
Move file patterns to a higher level to be able to use it on any analyzer

### DIFF
--- a/analyzer/all/import.go
+++ b/analyzer/all/import.go
@@ -2,6 +2,13 @@ package all
 
 import (
 	_ "github.com/aquasecurity/fanal/analyzer/command/apk"
+	_ "github.com/aquasecurity/fanal/analyzer/config/cloudformation"
+	_ "github.com/aquasecurity/fanal/analyzer/config/docker"
+	_ "github.com/aquasecurity/fanal/analyzer/config/hcl"
+	_ "github.com/aquasecurity/fanal/analyzer/config/json"
+	_ "github.com/aquasecurity/fanal/analyzer/config/terraform"
+	_ "github.com/aquasecurity/fanal/analyzer/config/toml"
+	_ "github.com/aquasecurity/fanal/analyzer/config/yaml"
 	_ "github.com/aquasecurity/fanal/analyzer/language/dotnet/nuget"
 	_ "github.com/aquasecurity/fanal/analyzer/language/golang/binary"
 	_ "github.com/aquasecurity/fanal/analyzer/language/golang/mod"

--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -175,6 +175,7 @@ func NewAnalyzerGroup(groupName Group, disabledAnalyzers []Type, filePatterns []
 		if len(s) != 2 {
 			return group, xerrors.Errorf("invalid file pattern (%s)", p)
 		}
+
 		fileType, pattern := s[0], s[1]
 		r, err := regexp.Compile(pattern)
 		if err != nil {

--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -368,28 +368,6 @@ func TestAnalyzeFile(t *testing.T) {
 			},
 		},
 		{
-			name: "happy path with library analyzer file pattern",
-			args: args{
-				filePath:     "/app/Gemfile-dev.lock",
-				testFilePath: "testdata/app/Gemfile.lock",
-				filePatterns: []string{"bundler:Gemfile(-.*)?\\.lock"},
-			},
-			want: &analyzer.AnalysisResult{
-				Applications: []types.Application{
-					{
-						Type:     "bundler",
-						FilePath: "/app/Gemfile-dev.lock",
-						Libraries: []types.Package{
-							{
-								Name:    "actioncable",
-								Version: "5.2.3",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
 			name: "sad path with opener error",
 			args: args{
 				filePath:     "/lib/apk/db/installed",

--- a/analyzer/config/cloudformation/cloudformation.go
+++ b/analyzer/config/cloudformation/cloudformation.go
@@ -12,6 +12,10 @@ import (
 	"golang.org/x/xerrors"
 )
 
+func init() {
+	analyzer.RegisterAnalyzer(&cloudFormationConfigAnalyzer{})
+}
+
 const version = 1
 
 var requiredExts = []string{".yaml", ".json", ".yml"}
@@ -22,15 +26,10 @@ var cloudFormationMatchRegex = []*regexp.Regexp{
 	regexp.MustCompile(`(?i)(?m)^\s*?["|]?Parameters[:|"]?`),
 }
 
-type ConfigAnalyzer struct {
-}
-
-func NewConfigAnalyzer() ConfigAnalyzer {
-	return ConfigAnalyzer{}
-}
+type cloudFormationConfigAnalyzer struct{}
 
 // Analyze returns a results of CloudFormation file
-func (a ConfigAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
+func (a cloudFormationConfigAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
 	content, err := io.ReadAll(input.Content)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to read the CloudFormation file: %w", err)
@@ -49,7 +48,7 @@ func (a ConfigAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput)
 	return &analyzer.AnalysisResult{}, nil
 }
 
-func (a ConfigAnalyzer) Required(filePath string, _ os.FileInfo) bool {
+func (a cloudFormationConfigAnalyzer) Required(filePath string, _ os.FileInfo) bool {
 	for _, extension := range requiredExts {
 		if filepath.Ext(filePath) == extension {
 			return true
@@ -58,11 +57,11 @@ func (a ConfigAnalyzer) Required(filePath string, _ os.FileInfo) bool {
 	return false
 }
 
-func (ConfigAnalyzer) Type() analyzer.Type {
+func (cloudFormationConfigAnalyzer) Type() analyzer.Type {
 	return analyzer.TypeCloudFormation
 }
 
-func (ConfigAnalyzer) Version() int {
+func (cloudFormationConfigAnalyzer) Version() int {
 	return version
 }
 

--- a/analyzer/config/cloudformation/cloudformation_test.go
+++ b/analyzer/config/cloudformation/cloudformation_test.go
@@ -116,7 +116,7 @@ spec:
        "bar", 
        "baa"
     ]
-}hcl.NewConfigAnalyzer
+}
 `),
 			filePath: "random.yaml",
 			want:     0,

--- a/analyzer/config/cloudformation/cloudformation_test.go
+++ b/analyzer/config/cloudformation/cloudformation_test.go
@@ -41,7 +41,7 @@ func TestConfigAnalyzer_Required(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			a := ConfigAnalyzer{}
+			a := cloudFormationConfigAnalyzer{}
 			got := a.Required(tt.filePath, nil)
 			assert.Equal(t, tt.want, got)
 		})
@@ -116,7 +116,7 @@ spec:
        "bar", 
        "baa"
     ]
-}
+}hcl.NewConfigAnalyzer
 `),
 			filePath: "random.yaml",
 			want:     0,
@@ -124,7 +124,7 @@ spec:
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			a := ConfigAnalyzer{}
+			a := cloudFormationConfigAnalyzer{}
 			got, err := a.Analyze(context.Background(), analyzer.AnalysisInput{
 				FilePath: tt.filePath,
 				Content:  tt.content,

--- a/analyzer/config/config.go
+++ b/analyzer/config/config.go
@@ -1,77 +1,18 @@
 package config
 
 import (
-	"regexp"
 	"sort"
-	"strings"
-
-	"github.com/aquasecurity/fanal/analyzer/config/cloudformation"
-	"golang.org/x/xerrors"
-
-	"github.com/aquasecurity/fanal/analyzer"
-	"github.com/aquasecurity/fanal/analyzer/config/docker"
-	"github.com/aquasecurity/fanal/analyzer/config/hcl"
-	"github.com/aquasecurity/fanal/analyzer/config/json"
-	"github.com/aquasecurity/fanal/analyzer/config/terraform"
-	"github.com/aquasecurity/fanal/analyzer/config/toml"
-	"github.com/aquasecurity/fanal/analyzer/config/yaml"
-	"github.com/aquasecurity/fanal/types"
 )
 
-const separator = ":"
-
 type ScannerOption struct {
-	Trace        bool
-	Namespaces   []string
-	FilePatterns []string
-	PolicyPaths  []string
-	DataPaths    []string
+	Trace       bool
+	Namespaces  []string
+	PolicyPaths []string
+	DataPaths   []string
 }
 
 func (o *ScannerOption) Sort() {
 	sort.Strings(o.Namespaces)
-	sort.Strings(o.FilePatterns)
 	sort.Strings(o.PolicyPaths)
 	sort.Strings(o.DataPaths)
-}
-
-func RegisterConfigAnalyzers(filePatterns []string) error {
-	var dockerRegexp, hclRegexp, jsonRegexp, tomlRegexp, yamlRegexp *regexp.Regexp
-	for _, p := range filePatterns {
-		// e.g. "dockerfile:my_dockerfile_*"
-		s := strings.SplitN(p, separator, 2)
-		if len(s) != 2 {
-			return xerrors.Errorf("invalid file pattern (%s)", p)
-		}
-		fileType, pattern := s[0], s[1]
-		r, err := regexp.Compile(pattern)
-		if err != nil {
-			return xerrors.Errorf("invalid file regexp (%s): %w", p, err)
-		}
-
-		switch fileType {
-		case types.Dockerfile:
-			dockerRegexp = r
-		case types.HCL:
-			hclRegexp = r
-		case types.JSON:
-			jsonRegexp = r
-		case types.TOML:
-			tomlRegexp = r
-		case types.YAML:
-			yamlRegexp = r
-		default:
-			return xerrors.Errorf("unknown file type: %s, pattern: %s", fileType, pattern)
-		}
-	}
-
-	analyzer.RegisterAnalyzer(docker.NewConfigAnalyzer(dockerRegexp))
-	analyzer.RegisterAnalyzer(hcl.NewConfigAnalyzer(hclRegexp))
-	analyzer.RegisterAnalyzer(json.NewConfigAnalyzer(jsonRegexp))
-	analyzer.RegisterAnalyzer(terraform.NewConfigAnalyzer())
-	analyzer.RegisterAnalyzer(cloudformation.NewConfigAnalyzer())
-	analyzer.RegisterAnalyzer(toml.NewConfigAnalyzer(tomlRegexp))
-	analyzer.RegisterAnalyzer(yaml.NewConfigAnalyzer(yamlRegexp))
-
-	return nil
 }

--- a/analyzer/config/config_test.go
+++ b/analyzer/config/config_test.go
@@ -10,10 +10,9 @@ import (
 
 func TestScannerOption_Sort(t *testing.T) {
 	type fields struct {
-		Namespaces   []string
-		FilePatterns []string
-		PolicyPaths  []string
-		DataPaths    []string
+		Namespaces  []string
+		PolicyPaths []string
+		DataPaths   []string
 	}
 	tests := []struct {
 		name   string
@@ -23,25 +22,22 @@ func TestScannerOption_Sort(t *testing.T) {
 		{
 			name: "happy path",
 			fields: fields{
-				Namespaces:   []string{"main", "custom", "default"},
-				FilePatterns: []string{"dockerfile:foo*", "yaml:yml_*"},
-				PolicyPaths:  []string{"policy"},
-				DataPaths:    []string{"data/b", "data/c", "data/a"},
+				Namespaces:  []string{"main", "custom", "default"},
+				PolicyPaths: []string{"policy"},
+				DataPaths:   []string{"data/b", "data/c", "data/a"},
 			},
 			want: config.ScannerOption{
-				Namespaces:   []string{"custom", "default", "main"},
-				FilePatterns: []string{"dockerfile:foo*", "yaml:yml_*"},
-				PolicyPaths:  []string{"policy"},
-				DataPaths:    []string{"data/a", "data/b", "data/c"},
+				Namespaces:  []string{"custom", "default", "main"},
+				PolicyPaths: []string{"policy"},
+				DataPaths:   []string{"data/a", "data/b", "data/c"},
 			},
 		},
 		{
 			name: "missing some fields",
 			fields: fields{
-				Namespaces:   []string{"main"},
-				FilePatterns: nil,
-				PolicyPaths:  nil,
-				DataPaths:    nil,
+				Namespaces:  []string{"main"},
+				PolicyPaths: nil,
+				DataPaths:   nil,
 			},
 			want: config.ScannerOption{
 				Namespaces: []string{"main"},
@@ -51,10 +47,9 @@ func TestScannerOption_Sort(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			o := config.ScannerOption{
-				Namespaces:   tt.fields.Namespaces,
-				FilePatterns: tt.fields.FilePatterns,
-				PolicyPaths:  tt.fields.PolicyPaths,
-				DataPaths:    tt.fields.DataPaths,
+				Namespaces:  tt.fields.Namespaces,
+				PolicyPaths: tt.fields.PolicyPaths,
+				DataPaths:   tt.fields.DataPaths,
 			}
 			o.Sort()
 

--- a/analyzer/config/docker/docker.go
+++ b/analyzer/config/docker/docker.go
@@ -2,7 +2,6 @@ package docker
 
 import (
 	"context"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -29,8 +28,6 @@ type dockerConfigAnalyzer struct {
 }
 
 func (s dockerConfigAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
-	log.Println(input.FilePath)
-	log.Println(input.Dir)
 	parsed, err := s.parser.Parse(input.Content)
 	if err != nil {
 		return nil, xerrors.Errorf("unable to parse Dockerfile (%s): %w", input.FilePath, err)

--- a/analyzer/config/docker/docker_test.go
+++ b/analyzer/config/docker/docker_test.go
@@ -2,7 +2,6 @@ package docker
 
 import (
 	"context"
-	"github.com/aquasecurity/fanal/config/parser/dockerfile"
 	"os"
 	"testing"
 
@@ -10,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/aquasecurity/fanal/analyzer"
+	"github.com/aquasecurity/fanal/config/parser/dockerfile"
 	"github.com/aquasecurity/fanal/types"
 )
 

--- a/analyzer/config/hcl/hcl.go
+++ b/analyzer/config/hcl/hcl.go
@@ -2,37 +2,31 @@ package hcl
 
 import (
 	"context"
-	"io"
-	"os"
-	"path/filepath"
-	"regexp"
-
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/hcl"
 	"golang.org/x/xerrors"
+	"io"
+	"os"
+	"path/filepath"
 
 	"github.com/aquasecurity/fanal/analyzer"
 	"github.com/aquasecurity/fanal/config/parser/hcl2"
 	"github.com/aquasecurity/fanal/types"
 )
 
+func init() {
+	analyzer.RegisterAnalyzer(&hclConfigAnalyzer{})
+}
+
 const version = 1
 
 var requiredExts = []string{".hcl", ".hcl1", ".hcl2"}
 
-type ConfigAnalyzer struct {
-	filePattern *regexp.Regexp
-}
-
-func NewConfigAnalyzer(filePattern *regexp.Regexp) ConfigAnalyzer {
-	return ConfigAnalyzer{
-		filePattern: filePattern,
-	}
-}
+type hclConfigAnalyzer struct{}
 
 // Analyze analyzes HCL-based config files, defaulting to HCL2.0 spec
 // it returns error only if content does not comply to both HCL2.0 and HCL1.0 spec
-func (a ConfigAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
+func (a hclConfigAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
 	parsed, err := a.analyze(input)
 	if err != nil {
 		return nil, xerrors.Errorf("unable to parse HCL (%a): %w", input.FilePath, err)
@@ -49,7 +43,7 @@ func (a ConfigAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput)
 	}, nil
 }
 
-func (a ConfigAnalyzer) analyze(target analyzer.AnalysisInput) (interface{}, error) {
+func (a hclConfigAnalyzer) analyze(target analyzer.AnalysisInput) (interface{}, error) {
 	var errs error
 	var parsed interface{}
 
@@ -73,11 +67,7 @@ func (a ConfigAnalyzer) analyze(target analyzer.AnalysisInput) (interface{}, err
 	return nil, errs
 }
 
-func (a ConfigAnalyzer) Required(filePath string, _ os.FileInfo) bool {
-	if a.filePattern != nil && a.filePattern.MatchString(filePath) {
-		return true
-	}
-
+func (a hclConfigAnalyzer) Required(filePath string, _ os.FileInfo) bool {
 	ext := filepath.Ext(filePath)
 	for _, required := range requiredExts {
 		if ext == required {
@@ -87,10 +77,10 @@ func (a ConfigAnalyzer) Required(filePath string, _ os.FileInfo) bool {
 	return false
 }
 
-func (ConfigAnalyzer) Type() analyzer.Type {
+func (hclConfigAnalyzer) Type() analyzer.Type {
 	return analyzer.TypeHCL
 }
 
-func (ConfigAnalyzer) Version() int {
+func (hclConfigAnalyzer) Version() int {
 	return version
 }

--- a/analyzer/config/hcl/hcl.go
+++ b/analyzer/config/hcl/hcl.go
@@ -2,12 +2,13 @@ package hcl
 
 import (
 	"context"
-	multierror "github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/hcl"
-	"golang.org/x/xerrors"
 	"io"
 	"os"
 	"path/filepath"
+
+	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/hcl"
+	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/fanal/analyzer"
 	"github.com/aquasecurity/fanal/config/parser/hcl2"

--- a/analyzer/config/hcl/hcl_test.go
+++ b/analyzer/config/hcl/hcl_test.go
@@ -1,16 +1,14 @@
-package hcl_test
+package hcl
 
 import (
 	"context"
 	"os"
-	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/aquasecurity/fanal/analyzer"
-	"github.com/aquasecurity/fanal/analyzer/config/hcl"
 	"github.com/aquasecurity/fanal/types"
 )
 
@@ -115,7 +113,7 @@ func TestConfigAnalyzer_Analyze(t *testing.T) {
 			require.NoError(t, err)
 			defer f.Close()
 
-			a := hcl.NewConfigAnalyzer(nil)
+			a := &hclConfigAnalyzer{}
 			require.NoError(t, err)
 			ctx := context.Background()
 			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
@@ -136,10 +134,9 @@ func TestConfigAnalyzer_Analyze(t *testing.T) {
 
 func TestConfigAnalyzer_Required(t *testing.T) {
 	tests := []struct {
-		name        string
-		filePattern *regexp.Regexp
-		filePath    string
-		want        bool
+		name     string
+		filePath string
+		want     bool
 	}{
 		{
 			name:     "hcl",
@@ -161,23 +158,17 @@ func TestConfigAnalyzer_Required(t *testing.T) {
 			filePath: "deployment.json",
 			want:     false,
 		},
-		{
-			name:        "file pattern",
-			filePattern: regexp.MustCompile(`foo*`),
-			filePath:    "foo_file",
-			want:        true,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := hcl.NewConfigAnalyzer(tt.filePattern)
+			s := &hclConfigAnalyzer{}
 			got := s.Required(tt.filePath, nil)
 			assert.Equal(t, tt.want, got)
 		})
 	}
 }
 func TestConfigAnalyzer_Type(t *testing.T) {
-	s := hcl.NewConfigAnalyzer(nil)
+	s := &hclConfigAnalyzer{}
 	want := analyzer.TypeHCL
 	got := s.Type()
 	assert.Equal(t, want, got)

--- a/analyzer/config/json/json.go
+++ b/analyzer/config/json/json.go
@@ -3,9 +3,10 @@ package json
 import (
 	"context"
 	"encoding/json"
-	"golang.org/x/xerrors"
 	"os"
 	"path/filepath"
+
+	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/fanal/analyzer"
 	"github.com/aquasecurity/fanal/types"

--- a/analyzer/config/json/json_test.go
+++ b/analyzer/config/json/json_test.go
@@ -1,16 +1,14 @@
-package json_test
+package json
 
 import (
 	"context"
 	"os"
-	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/aquasecurity/fanal/analyzer"
-	"github.com/aquasecurity/fanal/analyzer/config/json"
 	"github.com/aquasecurity/fanal/types"
 )
 
@@ -132,7 +130,7 @@ func Test_jsonConfigAnalyzer_Analyze(t *testing.T) {
 			require.NoError(t, err)
 			defer f.Close()
 
-			s := json.NewConfigAnalyzer(nil)
+			s := &jsonConfigAnalyzer{}
 
 			ctx := context.Background()
 			got, err := s.Analyze(ctx, analyzer.AnalysisInput{
@@ -153,10 +151,9 @@ func Test_jsonConfigAnalyzer_Analyze(t *testing.T) {
 
 func Test_jsonConfigAnalyzer_Required(t *testing.T) {
 	tests := []struct {
-		name        string
-		filePattern *regexp.Regexp
-		filePath    string
-		want        bool
+		name     string
+		filePath string
+		want     bool
 	}{
 		{
 			name:     "json",
@@ -173,16 +170,10 @@ func Test_jsonConfigAnalyzer_Required(t *testing.T) {
 			filePath: "package-lock.json",
 			want:     false,
 		},
-		{
-			name:        "file pattern",
-			filePattern: regexp.MustCompile(`foo*`),
-			filePath:    "foo_file",
-			want:        true,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := json.NewConfigAnalyzer(tt.filePattern)
+			s := &jsonConfigAnalyzer{}
 
 			got := s.Required(tt.filePath, nil)
 			assert.Equal(t, tt.want, got)
@@ -191,7 +182,7 @@ func Test_jsonConfigAnalyzer_Required(t *testing.T) {
 }
 
 func Test_jsonConfigAnalyzer_Type(t *testing.T) {
-	s := json.NewConfigAnalyzer(nil)
+	s := &jsonConfigAnalyzer{}
 
 	want := analyzer.TypeJSON
 	got := s.Type()

--- a/analyzer/config/terraform/terraform.go
+++ b/analyzer/config/terraform/terraform.go
@@ -9,19 +9,18 @@ import (
 	"github.com/aquasecurity/fanal/types"
 )
 
+func init() {
+	analyzer.RegisterAnalyzer(&terraformConfigAnalyzer{})
+}
+
 const version = 1
 
 const requiredExt = ".tf"
 
-type ConfigAnalyzer struct {
-}
-
-func NewConfigAnalyzer() ConfigAnalyzer {
-	return ConfigAnalyzer{}
-}
+type terraformConfigAnalyzer struct{}
 
 // Analyze returns a name of Terraform file
-func (a ConfigAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
+func (a terraformConfigAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (*analyzer.AnalysisResult, error) {
 	return &analyzer.AnalysisResult{
 		Configs: []types.Config{
 			{
@@ -32,14 +31,14 @@ func (a ConfigAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput)
 	}, nil
 }
 
-func (a ConfigAnalyzer) Required(filePath string, _ os.FileInfo) bool {
+func (a terraformConfigAnalyzer) Required(filePath string, _ os.FileInfo) bool {
 	return filepath.Ext(filePath) == requiredExt
 }
 
-func (ConfigAnalyzer) Type() analyzer.Type {
+func (terraformConfigAnalyzer) Type() analyzer.Type {
 	return analyzer.TypeTerraform
 }
 
-func (ConfigAnalyzer) Version() int {
+func (terraformConfigAnalyzer) Version() int {
 	return version
 }

--- a/analyzer/config/terraform/terraform_test.go
+++ b/analyzer/config/terraform/terraform_test.go
@@ -1,4 +1,4 @@
-package terraform_test
+package terraform
 
 import (
 	"context"
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/aquasecurity/fanal/analyzer"
-	"github.com/aquasecurity/fanal/analyzer/config/terraform"
 	"github.com/aquasecurity/fanal/types"
 )
 
@@ -36,7 +35,7 @@ func TestConfigAnalyzer_Analyze(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			a := terraform.ConfigAnalyzer{}
+			a := &terraformConfigAnalyzer{}
 			ctx := context.Background()
 			got, err := a.Analyze(ctx, tt.input)
 
@@ -70,7 +69,7 @@ func TestConfigAnalyzer_Required(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			a := terraform.ConfigAnalyzer{}
+			a := &terraformConfigAnalyzer{}
 			got := a.Required(tt.filePath, nil)
 			assert.Equal(t, tt.want, got)
 		})

--- a/analyzer/config/toml/toml.go
+++ b/analyzer/config/toml/toml.go
@@ -2,9 +2,10 @@ package toml
 
 import (
 	"context"
-	"golang.org/x/xerrors"
 	"os"
 	"path/filepath"
+
+	"golang.org/x/xerrors"
 
 	"github.com/BurntSushi/toml"
 	"github.com/aquasecurity/fanal/analyzer"

--- a/analyzer/config/toml/toml_test.go
+++ b/analyzer/config/toml/toml_test.go
@@ -1,16 +1,14 @@
-package toml_test
+package toml
 
 import (
 	"context"
 	"os"
-	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/aquasecurity/fanal/analyzer"
-	"github.com/aquasecurity/fanal/analyzer/config/toml"
 	"github.com/aquasecurity/fanal/types"
 )
 
@@ -94,7 +92,7 @@ func Test_tomlConfigAnalyzer_Analyze(t *testing.T) {
 			require.NoError(t, err)
 			defer f.Close()
 
-			a := toml.NewConfigAnalyzer(nil)
+			a := &tomlConfigAnalyzer{}
 			ctx := context.Background()
 			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: tt.inputFile,
@@ -114,10 +112,9 @@ func Test_tomlConfigAnalyzer_Analyze(t *testing.T) {
 
 func Test_tomlConfigAnalyzer_Required(t *testing.T) {
 	tests := []struct {
-		name        string
-		filePattern *regexp.Regexp
-		filePath    string
-		want        bool
+		name     string
+		filePath string
+		want     bool
 	}{
 		{
 			name:     "toml",
@@ -129,16 +126,10 @@ func Test_tomlConfigAnalyzer_Required(t *testing.T) {
 			filePath: "deployment.json",
 			want:     false,
 		},
-		{
-			name:        "file pattern",
-			filePattern: regexp.MustCompile(`foo*`),
-			filePath:    "foo_file",
-			want:        true,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := toml.NewConfigAnalyzer(tt.filePattern)
+			s := &tomlConfigAnalyzer{}
 
 			got := s.Required(tt.filePath, nil)
 			assert.Equal(t, tt.want, got)
@@ -147,7 +138,7 @@ func Test_tomlConfigAnalyzer_Required(t *testing.T) {
 }
 
 func Test_tomlConfigAnalyzer_Type(t *testing.T) {
-	s := toml.NewConfigAnalyzer(nil)
+	s := &tomlConfigAnalyzer{}
 
 	want := analyzer.TypeTOML
 	got := s.Type()

--- a/analyzer/config/yaml/yaml.go
+++ b/analyzer/config/yaml/yaml.go
@@ -2,10 +2,11 @@ package yaml
 
 import (
 	"context"
-	"golang.org/x/xerrors"
 	"io"
 	"os"
 	"path/filepath"
+
+	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/fanal/analyzer"
 	"github.com/aquasecurity/fanal/config/parser/yaml"

--- a/analyzer/config/yaml/yaml_test.go
+++ b/analyzer/config/yaml/yaml_test.go
@@ -1,16 +1,15 @@
-package yaml_test
+package yaml
 
 import (
 	"context"
 	"os"
-	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/aquasecurity/fanal/analyzer"
-	"github.com/aquasecurity/fanal/analyzer/config/yaml"
+	"github.com/aquasecurity/fanal/config/parser/yaml"
 	"github.com/aquasecurity/fanal/types"
 )
 
@@ -217,7 +216,9 @@ func Test_yamlConfigAnalyzer_Analyze(t *testing.T) {
 			require.NoError(t, err)
 			defer f.Close()
 
-			a := yaml.NewConfigAnalyzer(nil)
+			a := &yamlConfigAnalyzer{
+				parser: &yaml.Parser{},
+			}
 			ctx := context.Background()
 			got, err := a.Analyze(ctx, analyzer.AnalysisInput{
 				FilePath: tt.inputFile,
@@ -237,10 +238,9 @@ func Test_yamlConfigAnalyzer_Analyze(t *testing.T) {
 
 func Test_yamlConfigAnalyzer_Required(t *testing.T) {
 	tests := []struct {
-		name        string
-		filePattern *regexp.Regexp
-		filePath    string
-		want        bool
+		name     string
+		filePath string
+		want     bool
 	}{
 		{
 			name:     "yaml",
@@ -257,16 +257,12 @@ func Test_yamlConfigAnalyzer_Required(t *testing.T) {
 			filePath: "deployment.json",
 			want:     false,
 		},
-		{
-			name:        "file pattern",
-			filePattern: regexp.MustCompile(`foo*`),
-			filePath:    "foo_file",
-			want:        true,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := yaml.NewConfigAnalyzer(tt.filePattern)
+			s := &yamlConfigAnalyzer{
+				parser: &yaml.Parser{},
+			}
 
 			got := s.Required(tt.filePath, nil)
 			assert.Equal(t, tt.want, got)
@@ -275,7 +271,9 @@ func Test_yamlConfigAnalyzer_Required(t *testing.T) {
 }
 
 func Test_yamlConfigAnalyzer_Type(t *testing.T) {
-	s := yaml.NewConfigAnalyzer(nil)
+	s := &yamlConfigAnalyzer{
+		parser: &yaml.Parser{},
+	}
 
 	want := analyzer.TypeYaml
 	got := s.Type()

--- a/artifact/artifact.go
+++ b/artifact/artifact.go
@@ -15,6 +15,7 @@ type Option struct {
 	DisabledHooks     []hook.Type
 	SkipFiles         []string
 	SkipDirs          []string
+	FilePatterns      []string
 	Quiet             bool
 	Offline           bool
 	InsecureSkipTLS   bool
@@ -26,6 +27,7 @@ func (o *Option) Sort() {
 	})
 	sort.Strings(o.SkipFiles)
 	sort.Strings(o.SkipDirs)
+	sort.Strings(o.FilePatterns)
 }
 
 type Artifact interface {

--- a/artifact/image/image.go
+++ b/artifact/image/image.go
@@ -40,12 +40,12 @@ type Artifact struct {
 }
 
 func NewArtifact(img types.Image, c cache.ArtifactCache, artifactOpt artifact.Option, scannerOpt config.ScannerOption) (artifact.Artifact, error) {
-	// Register config analyzers
-	if err := config.RegisterConfigAnalyzers(scannerOpt.FilePatterns); err != nil {
-		return nil, xerrors.Errorf("config scanner error: %w", err)
+	s, err := scanner.New("", scannerOpt.Namespaces, scannerOpt.PolicyPaths, scannerOpt.DataPaths, scannerOpt.Trace)
+	if err != nil {
+		return nil, xerrors.Errorf("scanner error: %w", err)
 	}
 
-	s, err := scanner.New("", scannerOpt.Namespaces, scannerOpt.PolicyPaths, scannerOpt.DataPaths, scannerOpt.Trace)
+	a, err := analyzer.NewAnalyzerGroup(artifactOpt.AnalyzerGroup, artifactOpt.DisabledAnalyzers, artifactOpt.FilePatterns)
 	if err != nil {
 		return nil, xerrors.Errorf("scanner error: %w", err)
 	}
@@ -54,7 +54,7 @@ func NewArtifact(img types.Image, c cache.ArtifactCache, artifactOpt artifact.Op
 		image:       img,
 		cache:       c,
 		walker:      walker.NewLayerTar(artifactOpt.SkipFiles, artifactOpt.SkipDirs),
-		analyzer:    analyzer.NewAnalyzerGroup(artifactOpt.AnalyzerGroup, artifactOpt.DisabledAnalyzers),
+		analyzer:    a,
 		hookManager: hook.NewManager(artifactOpt.DisabledHooks),
 		scanner:     s,
 

--- a/artifact/remote/git_test.go
+++ b/artifact/remote/git_test.go
@@ -107,9 +107,9 @@ func TestArtifact_Inspect(t *testing.T) {
 			want: types.ArtifactReference{
 				Name: ts.URL + "/test.git",
 				Type: types.ArtifactRemoteRepository,
-				ID:   "sha256:8dd3e15371c90ab4efcc15dea5c8cc1fac9a8c273c5208ad25a562074fd099cc",
+				ID:   "sha256:c3f109c4b5b9000e41c436262d19d2bd48be6b14681e441a3d2bf4e6e21e41fc",
 				BlobIDs: []string{
-					"sha256:8dd3e15371c90ab4efcc15dea5c8cc1fac9a8c273c5208ad25a562074fd099cc",
+					"sha256:c3f109c4b5b9000e41c436262d19d2bd48be6b14681e441a3d2bf4e6e21e41fc",
 				},
 			},
 		},

--- a/cache/key.go
+++ b/cache/key.go
@@ -20,14 +20,15 @@ func CalcKey(id string, analyzerVersions, hookVersions map[string]int, artifactO
 
 	h := sha256.New()
 
-	// Write ID, analyzer/hook versions, and skipped files/dirs
+	// Write ID, analyzer/hook versions, skipped files/dirs and file patterns
 	keyBase := struct {
 		ID               string
 		AnalyzerVersions map[string]int
 		HookVersions     map[string]int
 		SkipFiles        []string
 		SkipDirs         []string
-	}{id, analyzerVersions, hookVersions, artifactOpt.SkipFiles, artifactOpt.SkipDirs}
+		FilePatterns     []string `json:",omitempty"`
+	}{id, analyzerVersions, hookVersions, artifactOpt.SkipFiles, artifactOpt.SkipDirs, artifactOpt.FilePatterns}
 
 	if err := json.NewEncoder(h).Encode(keyBase); err != nil {
 		return "", xerrors.Errorf("json encode error: %w", err)

--- a/cache/key_test.go
+++ b/cache/key_test.go
@@ -162,9 +162,8 @@ func TestCalcKey(t *testing.T) {
 				SkipDirs:  tt.args.skipDirs,
 			}
 			scannerOpt := config.ScannerOption{
-				FilePatterns: tt.args.patterns,
-				PolicyPaths:  tt.args.policy,
-				DataPaths:    tt.args.data,
+				PolicyPaths: tt.args.policy,
+				DataPaths:   tt.args.data,
 			}
 			got, err := CalcKey(tt.args.key, tt.args.analyzerVersions, tt.args.hookVersions, artifactOpt, scannerOpt)
 			if tt.wantErr != "" {

--- a/cache/key_test.go
+++ b/cache/key_test.go
@@ -78,7 +78,7 @@ func TestCalcKey(t *testing.T) {
 				},
 				patterns: []string{""},
 			},
-			want: "sha256:d69f13df33f4c159b4ea54c1967384782fcefb5e2a19af35f4cd6d2896e9285e",
+			want: "sha256:9b81e0bf3aa7809a0f41bc696f353fca5645bcb63b975ab30e23d81886df2e61",
 		},
 		{
 			name: "with single non empty string in file patterns",
@@ -90,7 +90,7 @@ func TestCalcKey(t *testing.T) {
 				},
 				patterns: []string{"test"},
 			},
-			want: "sha256:d69f13df33f4c159b4ea54c1967384782fcefb5e2a19af35f4cd6d2896e9285e",
+			want: "sha256:7d91b2623ae4b5641a1f36efa59c774231efe8c28c27a03869894fd49b047fe8",
 		},
 		{
 			name: "with non empty followed by empty string in file patterns",
@@ -102,7 +102,7 @@ func TestCalcKey(t *testing.T) {
 				},
 				patterns: []string{"test", ""},
 			},
-			want: "sha256:d69f13df33f4c159b4ea54c1967384782fcefb5e2a19af35f4cd6d2896e9285e",
+			want: "sha256:5c7f1555e95fc60cdaa7e92e99aee15ee7be356fad9e83f1c24a3be06713a5a8",
 		},
 		{
 			name: "with non empty preceded by empty string in file patterns",
@@ -114,7 +114,7 @@ func TestCalcKey(t *testing.T) {
 				},
 				patterns: []string{"", "test"},
 			},
-			want: "sha256:d69f13df33f4c159b4ea54c1967384782fcefb5e2a19af35f4cd6d2896e9285e",
+			want: "sha256:5c7f1555e95fc60cdaa7e92e99aee15ee7be356fad9e83f1c24a3be06713a5a8",
 		},
 		{
 			name: "with policy",
@@ -158,8 +158,9 @@ func TestCalcKey(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			artifactOpt := artifact.Option{
-				SkipFiles: tt.args.skipFiles,
-				SkipDirs:  tt.args.skipDirs,
+				SkipFiles:    tt.args.skipFiles,
+				SkipDirs:     tt.args.skipDirs,
+				FilePatterns: tt.args.patterns,
 			}
 			scannerOpt := config.ScannerOption{
 				PolicyPaths: tt.args.policy,

--- a/external/config_scan.go
+++ b/external/config_scan.go
@@ -11,6 +11,8 @@ import (
 	"github.com/aquasecurity/fanal/artifact/local"
 	"github.com/aquasecurity/fanal/cache"
 	"github.com/aquasecurity/fanal/types"
+
+	_ "github.com/aquasecurity/fanal/analyzer/all"
 )
 
 type ConfigScanner struct {


### PR DESCRIPTION
This PR moves the file patterns feature from the config analyzers to a global level so that we can use it on any analyzer.
In favor of #370, #357, #355 as this fill allow you to set the needed file patterns yourself. 

This also makes the config analyzers more like the other analyzers.

We talked about asking the community, but IMHO it makes sense to just add it as it is a logical next step after having it in the config analyzers.

This can be enabled in Trivy without changing anything to the config scanner. The other commands will just get a `--filte-patterns` option, I already have a branch for that ready.

What do you think @knqyf263?