### PR TITLE
fix(hook): fix skip of language-specific files when scanning rootfs directory

### DIFF
--- a/hook/filter/filter.go
+++ b/hook/filter/filter.go
@@ -43,7 +43,8 @@ func (h systemFileFilterHook) Hook(blob *types.BlobInfo) error {
 	for _, file := range append(blob.SystemFiles, defaultSystemFiles...) {
 		// Trim leading slashes to be the same format as the path in container images.
 		systemFile := strings.TrimPrefix(file, "/")
-		// We should check this otherwise libraries with an empty filePath will be removed.
+		// We should check the root filepath ("/") and ignore it.
+		// Otherwise libraries with an empty filePath will be removed.
 		if systemFile != "" {
 			systemFiles = append(systemFiles, systemFile)
 		}

--- a/hook/filter/filter.go
+++ b/hook/filter/filter.go
@@ -42,7 +42,11 @@ func (h systemFileFilterHook) Hook(blob *types.BlobInfo) error {
 	var systemFiles []string
 	for _, file := range append(blob.SystemFiles, defaultSystemFiles...) {
 		// Trim leading slashes to be the same format as the path in container images.
-		systemFiles = append(systemFiles, strings.TrimPrefix(file, "/"))
+		systemFile := strings.TrimPrefix(file, "/")
+		// We should check this otherwise libraries with an empty filePath will be removed.
+		if systemFile != "" {
+			systemFiles = append(systemFiles, systemFile)
+		}
 	}
 
 	var apps []types.Application

--- a/hook/filter/filter_test.go
+++ b/hook/filter/filter_test.go
@@ -73,6 +73,7 @@ func Test_systemFileFilterHook_Hook(t *testing.T) {
 					},
 				},
 				SystemFiles: []string{
+					"/",
 					"/usr/bin/pydoc",
 					"/usr/bin/python",
 					"/usr/bin/python2",

--- a/hook/filter/filter_test.go
+++ b/hook/filter/filter_test.go
@@ -71,6 +71,17 @@ func Test_systemFileFilterHook_Hook(t *testing.T) {
 							},
 						},
 					},
+					{
+						Type:     types.GoBinary,
+						FilePath: "usr/local/bin/goBinariryFile",
+						Libraries: []types.Package{
+							{
+								Name:     "cloud.google.com/go",
+								Version:  "v0.81.0",
+								FilePath: "",
+							},
+						},
+					},
 				},
 				SystemFiles: []string{
 					"/",
@@ -128,6 +139,16 @@ func Test_systemFileFilterHook_Hook(t *testing.T) {
 								Name:     "pycurl",
 								Version:  "7.19.0",
 								FilePath: "usr/lib64/python2.7/site-packages/pycurl-7.19.0-py2.7.egg-info",
+							},
+						},
+					},
+					{
+						Type:     types.GoBinary,
+						FilePath: "usr/local/bin/goBinariryFile",
+						Libraries: []types.Package{
+							{
+								Name:    "cloud.google.com/go",
+								Version: "v0.81.0",
 							},
 						},
 					},


### PR DESCRIPTION
## Description
When scanning Amazonlinux or CentOS rootfs directory, RPM has SystemFile ="/". After trimming the "/" prefix, we have an empty SystemFile.
The filePath of some file libraries is empty. These libraries [will be removed](https://github.com/aquasecurity/fanal/blob/e8f5ba7a5e5e4ae4b4c05a9b2d1c554151e1fd58/hook/filter/filter.go#L64-L66).
#### Example:
##### Amazon Linux
1. Run docker container amazonlinux:2. 
2. Install `helmfile`
```
curl -LO https://github.com/roboll/helmfile/releases/download/v0.141.0/helmfile_linux_amd64 &&
mv helmfile_linux_amd64 /usr/local/bin/helmfile &&
chmod +x /usr/local/bin/helmfile
```
3. Start `trivy -d rootfs /`
4. Trivy [finds](https://github.com/aquasecurity/fanal/blob/e8f5ba7a5e5e4ae4b4c05a9b2d1c554151e1fd58/analyzer/pkg/rpm/rpm.go#L98) `helmfile` gobinary application:
```
2022-01-21T05:31:59.293Z	DEBUG	issue1592. Application.Type: 'gobinary'
2022-01-21T05:31:59.293Z	DEBUG	issue1592. Application.FilePath: 'usr/local/bin/helmfile'
2022-01-21T05:31:59.293Z	DEBUG	issue1592. Application.Libraries[0].Name: 'cloud.google.com/go'
2022-01-21T05:31:59.293Z	DEBUG	issue1592. Application.Libraries[0].Version: 'v0.81.0'
2022-01-21T05:31:59.293Z	DEBUG	issue1592. Application.Libraries[0].FilePath: ''
2022-01-21T05:31:59.293Z	DEBUG	issue1592. Application.Libraries[0].License: ''
  
 ```
5. Trivy [finds](https://github.com/aquasecurity/fanal/blob/e8f5ba7a5e5e4ae4b4c05a9b2d1c554151e1fd58/analyzer/pkg/rpm/rpm.go#L98) `filesystem-3.2-25.amzn2.0.4.src.rpm` package:
  
```
2022-01-21T04:48:13.826Z	DEBUG	issue1592. PackageInfo.Name: 'filesystem'
2022-01-21T04:48:13.826Z	DEBUG	issue1592. PackageInfo.Version: '3.2'
2022-01-21T04:48:13.826Z	DEBUG	issue1592. PackageInfo.Release: '25.amzn2.0.4'
2022-01-21T04:48:13.826Z	DEBUG	issue1592. PackageInfo.Epoch: '0'
2022-01-21T04:48:13.826Z	DEBUG	issue1592. PackageInfo.Arch: 'x86_64'
2022-01-21T04:48:13.826Z	DEBUG	issue1592. PackageInfo.SourceRpm: 'filesystem-3.2-25.amzn2.0.4.src.rpm'
2022-01-21T04:48:13.826Z	DEBUG	issue1592. PackageInfo.Size: '0'
2022-01-21T04:48:13.826Z	DEBUG	issue1592. PackageInfo.License: 'Public Domain'
2022-01-21T04:48:13.826Z	DEBUG	issue1592. PackageInfo.Vendor: 'Amazon Linux'
2022-01-21T04:48:13.826Z	DEBUG	issue1592. PackageInfo.BaseNames[0]: ''
2022-01-21T04:48:13.826Z	DEBUG	issue1592. PackageInfo.DirIndexes[0]: '0'
2022-01-21T04:48:13.826Z	DEBUG	issue1592. PackageInfo.DirNames[0]: '/'
2022-01-21T04:48:13.826Z	DEBUG	issue1592. FilePath[0]: '/'
2022-01-21T04:48:13.826Z	DEBUG	issue1592. PackageInfo.BaseNames[1]: 'bin'
2022-01-21T04:48:13.826Z	DEBUG	issue1592. PackageInfo.DirIndexes[1]: '0'
2022-01-21T04:48:13.826Z	DEBUG	issue1592. PackageInfo.DirNames[1]: '/etc/'
2022-01-21T04:48:13.826Z	DEBUG	issue1592. FilePath[1]: '/bin'
```
6. We have filePath = "/". [Add](https://github.com/aquasecurity/fanal/blob/e8f5ba7a5e5e4ae4b4c05a9b2d1c554151e1fd58/analyzer/pkg/rpm/rpm.go#L125) systemFile = "/".
7. [Trim](https://github.com/aquasecurity/fanal/blob/e8f5ba7a5e5e4ae4b4c05a9b2d1c554151e1fd58/hook/filter/filter.go#L45)  "/" prefix.
8. [Remove](https://github.com/aquasecurity/fanal/blob/e8f5ba7a5e5e4ae4b4c05a9b2d1c554151e1fd58/hook/filter/filter.go#L64-L66) all `helmfile` libraries, because they have filepath = "".

##### CentOS
  centos:8 has similar `filesystem-3.8-3.el8.src.rpm` package.
#### Done:
- Added check systemfile for emptiness.
- Added check SystemFile = "/" in test
## Related issues
-  aquasecurity/trivy/issues/1592
-  aquasecurity/trivy/issues/1626