### PR TITLE
chore(dependabot): set interval to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,9 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
   - package-ecosystem: gomod
     open-pull-requests-limit: 10
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly


### PR DESCRIPTION
## Description
We tried running Dependabot weekly for a while, but it was a bit noisy. This PR changes the interval to monthly.