### PR TITLE
feat(docker): add support for scanning docker image with ImageID

### DIFF
--- a/image/image_test.go
+++ b/image/image_test.go
@@ -23,6 +23,7 @@ func setupEngineAndRegistry() (*httptest.Server, *httptest.Server) {
 	imagePaths := map[string]string{
 		"index.docker.io/library/alpine:3.10": "../test/testdata/alpine-310.tar.gz",
 		"index.docker.io/library/alpine:3.11": "../test/testdata/alpine-311.tar.gz",
+		"a187dde48cd2":                        "../test/testdata/alpine-311.tar.gz",
 	}
 	opt := engine.Option{
 		APIVersion: "1.38",
@@ -66,9 +67,46 @@ func TestNewDockerImage(t *testing.T) {
 		wantErr         bool
 	}{
 		{
-			name: "happy path with Docker Engine",
+			name: "happy path with Docker Engine (use pattern <imageName>:<tag> for image name)",
 			args: args{
 				imageName: "alpine:3.11",
+			},
+			wantID:       "sha256:a187dde48cd289ac374ad8539930628314bc581a481cdb41409c9289419ddb72",
+			wantLayerIDs: []string{"sha256:beee9f30bc1f711043e78d4a2be0668955d4b761d587d6f60c2c8dc081efb203"},
+			wantRepoTags: []string{"alpine:3.11"},
+			wantConfigFile: &v1.ConfigFile{
+				Architecture:  "amd64",
+				Container:     "fb71ddde5f6411a82eb056a9190f0cc1c80d7f77a8509ee90a2054428edb0024",
+				OS:            "linux",
+				Created:       v1.Time{Time: time.Date(2020, 3, 23, 21, 19, 34, 196162891, time.UTC)},
+				DockerVersion: "18.09.7",
+				History: []v1.History{
+					{
+						Created:    v1.Time{Time: time.Date(2020, 3, 23, 21, 19, 34, 0, time.UTC)},
+						CreatedBy:  "/bin/sh -c #(nop)  CMD [\"/bin/sh\"]",
+						Comment:    "",
+						EmptyLayer: true,
+					},
+					{
+						Created:    v1.Time{Time: time.Date(2020, 3, 23, 21, 19, 34, 0, time.UTC)},
+						CreatedBy:  "/bin/sh -c #(nop) ADD file:0c4555f363c2672e350001f1293e689875a3760afe7b3f9146886afe67121cba in / ",
+						EmptyLayer: false,
+					},
+				},
+				RootFS: v1.RootFS{Type: "layers", DiffIDs: []v1.Hash{v1.Hash{Algorithm: "sha256", Hex: "beee9f30bc1f711043e78d4a2be0668955d4b761d587d6f60c2c8dc081efb203"}}},
+				Config: v1.Config{
+					Cmd:         []string{"/bin/sh"},
+					Env:         []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"},
+					Image:       "sha256:74df73bb19fbfc7fb5ab9a8234b3d98ee2fb92df5b824496679802685205ab8c",
+					ArgsEscaped: true,
+				},
+				OSVersion: "",
+			},
+		},
+		{
+			name: "happy path with Docker Engine (use pattern <ImageID> for image name)",
+			args: args{
+				imageName: "a187dde48cd2",
 			},
 			wantID:       "sha256:a187dde48cd289ac374ad8539930628314bc581a481cdb41409c9289419ddb72",
 			wantLayerIDs: []string{"sha256:beee9f30bc1f711043e78d4a2be0668955d4b761d587d6f60c2c8dc081efb203"},


### PR DESCRIPTION
## Description
Added support for scanning a docker image with ImageID. 
e.g. `trivy image 5ac716b05a9c`

## Issues
- aquasecurity/trivy/issues/1506
