### PR TITLE
fix(filter-hook): systemfiles filter for custom resources

### DIFF
--- a/hook/filter/filter.go
+++ b/hook/filter/filter.go
@@ -73,6 +73,17 @@ func (h systemFileFilterHook) Hook(blob *types.BlobInfo) error {
 		apps = append(apps, app)
 	}
 
+	// Iterate and delete unnecessary customResource
+	i := 0
+	for _, res := range blob.CustomResources {
+		if utils.StringInSlice(res.FilePath, systemFiles) {
+			continue
+		}
+		blob.CustomResources[i] = res
+		i++
+	}
+	blob.CustomResources = blob.CustomResources[:i]
+
 	// Overwrite Applications
 	blob.Applications = apps
 

--- a/hook/filter/filter_test.go
+++ b/hook/filter/filter_test.go
@@ -102,6 +102,16 @@ func Test_systemFileFilterHook_Hook(t *testing.T) {
 					"/usr/lib64/python2.7/lib-dynload/Python-2.7.5-py2.7.egg-info",
 					"usr/lib64/python2.7/wsgiref.egg-info", // without the leading slash
 				},
+				CustomResources: []types.CustomResource{
+					{
+						FilePath: "usr/bin/pydoc",
+						Data:     "remove",
+					},
+					{
+						FilePath: "usr/bin/pydoc/needed",
+						Data:     "shouldNotRemove",
+					},
+				},
 			},
 			want: &types.BlobInfo{
 				PackageInfos: []types.PackageInfo{
@@ -151,6 +161,13 @@ func Test_systemFileFilterHook_Hook(t *testing.T) {
 								Version: "v0.81.0",
 							},
 						},
+					},
+				},
+				CustomResources: []types.CustomResource{
+					{
+						FilePath: "usr/bin/pydoc/needed",
+						Data:     "shouldNotRemove",
+						Layer:    types.Layer{},
 					},
 				},
 			},


### PR DESCRIPTION
Currently Filter hook filters systemfiles resources from Applications and Packages.
Updated the hook to filter CustomResources as well. 