### PR TITLE
refactor(debug messages): change messages about missing Image and Layers in cache

### DIFF
--- a/artifact/image/image.go
+++ b/artifact/image/image.go
@@ -96,7 +96,7 @@ func (a Artifact) Inspect(ctx context.Context) (types.ArtifactReference, error) 
 
 	missingImageKey := imageKey
 	if missingImage {
-		log.Logger.Debugf("Missing image ID: %s", imageID)
+		log.Logger.Debugf("Missing image ID in cache: %s", imageID)
 	} else {
 		missingImageKey = ""
 	}
@@ -180,7 +180,6 @@ func (a Artifact) inspect(ctx context.Context, missingImage string, layerKeys []
 	}
 
 	if missingImage != "" {
-		log.Logger.Debugf("Missing image cache: %s", missingImage)
 		if err := a.inspectConfig(missingImage, osFound); err != nil {
 			return xerrors.Errorf("unable to analyze config: %w", err)
 		}
@@ -191,7 +190,7 @@ func (a Artifact) inspect(ctx context.Context, missingImage string, layerKeys []
 }
 
 func (a Artifact) inspectLayer(ctx context.Context, diffID string) (types.BlobInfo, error) {
-	log.Logger.Debugf("Missing diff ID: %s", diffID)
+	log.Logger.Debugf("Missing diff ID in cache: %s", diffID)
 
 	layerDigest, r, err := a.uncompressedLayer(diffID)
 	if err != nil {


### PR DESCRIPTION
## Description
Changed messages about missing `Image ID` and `Diff ID` in cache.
Removed repeated message about missing `Image ID`.

## Related issues
- aquasecurity/trivy/issues/1565