### PR TITLE
feat(dpkg): license parser added

### DIFF
--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -119,6 +119,10 @@ func (r *AnalysisResult) Sort() {
 			return app.Libraries[i].Version < app.Libraries[j].Version
 		})
 	}
+
+	sort.Slice(r.CustomResources, func(i, j int) bool {
+		return r.CustomResources[i].FilePath < r.CustomResources[j].FilePath
+	})
 }
 
 func (r *AnalysisResult) Merge(new *AnalysisResult) {

--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -462,6 +462,7 @@ func TestAnalyzer_AnalyzerVersions(t *testing.T) {
 				"apk":     1,
 				"bundler": 1,
 				"ubuntu":  1,
+				"dpkg":    2,
 			},
 		},
 		{
@@ -470,6 +471,7 @@ func TestAnalyzer_AnalyzerVersions(t *testing.T) {
 			want: map[string]int{
 				"apk":     1,
 				"bundler": 1,
+				"dpkg":    2,
 			},
 		},
 	}

--- a/analyzer/pkg/dpkg/copyright.go
+++ b/analyzer/pkg/dpkg/copyright.go
@@ -1,0 +1,90 @@
+package dpkg
+
+import (
+	"bufio"
+	"bytes"
+	"github.com/aquasecurity/fanal/analyzer"
+	"github.com/aquasecurity/fanal/types"
+	"github.com/aquasecurity/fanal/utils"
+	dio "github.com/aquasecurity/go-dep-parser/pkg/io"
+	classifier "github.com/google/licenseclassifier/v2/assets"
+	"io"
+	"regexp"
+	"strings"
+)
+
+const LicenseAdder = "dpkg-license-adder"
+
+var (
+	cl, _                = classifier.DefaultClassifier()
+	copyrightFileRegexp  = regexp.MustCompile(`/?usr/share/doc/([0-9A-Za-z_.-]+)/copyright`)
+	commonLicensesRegexp = regexp.MustCompile(`/?usr/share/common-licenses/([0-9A-Za-z_.+-]+[0-9A-Za-z+])`)
+)
+
+type License struct {
+	Pkg      string
+	Licenses string
+}
+
+// parseCopyrightFile parses /usr/share/doc/*/copyright files
+func parseCopyrightFile(content dio.ReadSeekerAt, filePath string) (*analyzer.AnalysisResult, error) {
+	var licenses []string
+	var buf bytes.Buffer
+
+	tee := io.TeeReader(content, &buf) // Save stream in buffer for re-read with 'licenseclassifier'
+	scanner := bufio.NewScanner(tee)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// "License: *" pattern is used
+		if strings.HasPrefix(line, "License:") {
+			l := strings.TrimSpace(line[8:])
+			if !utils.StringInSlice(l, licenses) {
+				licenses = append(licenses, l)
+			}
+			continue
+		}
+
+		// Common license pattern is used
+		license := commonLicensesRegexp.FindStringSubmatch(line)
+		if len(license) == 2 && !utils.StringInSlice(license[1], licenses) {
+			licenses = append(licenses, license[1])
+		}
+	}
+
+	// Use 'github.com/google/licenseclassifier' for find licenses
+	result := cl.Match(buf.Bytes())
+	for _, match := range result.Matches {
+		if !utils.StringInSlice(match.Name, licenses) {
+			licenses = append(licenses, match.Name)
+		}
+	}
+
+	licensesStr := strings.Join(licenses, ", ")
+	if licensesStr == "" {
+		licensesStr = "Unknown"
+	}
+
+	return &analyzer.AnalysisResult{
+		CustomResources: []types.CustomResource{
+			{
+				Type:     LicenseAdder,
+				FilePath: getPkgNameFromLicenseFilePath(filePath),
+				Data:     licensesStr,
+			},
+		},
+	}, nil
+}
+
+func isLicenseFile(filePath string) bool {
+	return copyrightFileRegexp.MatchString(filePath)
+}
+
+func getPkgNameFromLicenseFilePath(filePath string) string {
+	pkgName := copyrightFileRegexp.FindStringSubmatch(filePath)
+	if len(pkgName) == 2 {
+		return pkgName[1]
+	}
+	return ""
+}

--- a/analyzer/pkg/dpkg/copyright_test.go
+++ b/analyzer/pkg/dpkg/copyright_test.go
@@ -1,0 +1,121 @@
+package dpkg
+
+import (
+	"github.com/aquasecurity/fanal/analyzer"
+	"github.com/aquasecurity/fanal/types"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func TestDpkgAnalyzer_parseCopyrightFile(t *testing.T) {
+	tests := []struct {
+		name              string
+		copyrightFilePath string
+		wantLicense       *analyzer.AnalysisResult
+	}{
+		{
+			name:              "happy path. 'License:' pattern + licenseclassifier",
+			copyrightFilePath: "testdata/copyrightFiles/usr/share/doc/zlib1g/copyright",
+			wantLicense: &analyzer.AnalysisResult{
+				CustomResources: []types.CustomResource{
+					{
+						Type:     LicenseAdder,
+						FilePath: "zlib1g",
+						Data:     "Zlib",
+					},
+				},
+			},
+		},
+		{
+			name:              "happy path. Common license",
+			copyrightFilePath: "testdata/copyrightFiles/usr/share/doc/adduser/copyright",
+			wantLicense: &analyzer.AnalysisResult{
+				CustomResources: []types.CustomResource{
+					{
+						Type:     LicenseAdder,
+						FilePath: "adduser",
+						Data:     "GPL-2, GPL-2.0",
+					},
+				},
+			},
+		},
+		{
+			name:              "happy path. There are Common license, 'License:' pattern and licenseclassifier",
+			copyrightFilePath: "testdata/copyrightFiles/usr/share/doc/apt/copyright",
+			wantLicense: &analyzer.AnalysisResult{
+				CustomResources: []types.CustomResource{
+					{
+						Type:     LicenseAdder,
+						FilePath: "apt",
+						Data:     "GPLv2+, GPL-2, GPL-2.0",
+					},
+				},
+			},
+		},
+		{
+			name:              "happy path. Licenses not found",
+			copyrightFilePath: "testdata/copyrightFiles/usr/share/doc/tzdata/copyright",
+			wantLicense: &analyzer.AnalysisResult{
+				CustomResources: []types.CustomResource{
+					{
+						Type:     LicenseAdder,
+						FilePath: "tzdata",
+						Data:     "Unknown",
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			f, err := os.Open(test.copyrightFilePath)
+			if err != nil {
+				t.Error("unable to read test file")
+			}
+
+			license, _ := parseCopyrightFile(f, test.copyrightFilePath)
+			assert.Equal(t, test.wantLicense, license)
+		})
+	}
+}
+
+func TestDpkgAnalyzer_isLicenseFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		filePath string
+		want     bool
+	}{
+		{
+			name:     "happy path",
+			filePath: "/usr/share/doc/eject/copyright",
+			want:     true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, isLicenseFile(test.filePath))
+		})
+	}
+}
+
+func TestDpkgAnalyzer_getPkgNameFromLicenseFilePath(t *testing.T) {
+	tests := []struct {
+		name     string
+		filePath string
+		wantPkg  string
+	}{
+		{
+			name:     "happy path",
+			filePath: "/usr/share/doc/eject/copyright",
+			wantPkg:  "eject",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.wantPkg, getPkgNameFromLicenseFilePath(test.filePath))
+		})
+	}
+}

--- a/analyzer/pkg/dpkg/dpkg.go
+++ b/analyzer/pkg/dpkg/dpkg.go
@@ -41,6 +41,10 @@ func (a dpkgAnalyzer) Analyze(_ context.Context, input analyzer.AnalysisInput) (
 		return a.parseDpkgInfoList(scanner)
 	}
 
+	if isLicenseFile(input.FilePath) {
+		return parseCopyrightFile(input.Content, input.FilePath)
+	}
+
 	return a.parseDpkgStatus(input.FilePath, scanner)
 }
 
@@ -194,7 +198,7 @@ func (a dpkgAnalyzer) parseDpkgPkg(scanner *bufio.Scanner) (pkg *types.Package) 
 
 func (a dpkgAnalyzer) Required(filePath string, _ os.FileInfo) bool {
 	dir, fileName := filepath.Split(filePath)
-	if a.isListFile(dir, fileName) || filePath == statusFile {
+	if a.isListFile(dir, fileName) || filePath == statusFile || isLicenseFile(filePath) {
 		return true
 	}
 

--- a/analyzer/pkg/dpkg/testdata/copyrightFiles/usr/share/doc/adduser/copyright
+++ b/analyzer/pkg/dpkg/testdata/copyrightFiles/usr/share/doc/adduser/copyright
@@ -1,0 +1,47 @@
+This package was first put together by Ian Murdock
+<imurdock@debian.org> and was maintained by Steve Phillips
+<sjp@cvfn.org> from sources written for the Debian Project by Ian
+Murdock, Ted Hajek <tedhajek@boombox.micro.umn.edu>, and Sven Rudolph
+<sr1@inf.tu-dresden.de>.
+
+Since Nov 27 1996, it was maintained by Guy Maor <maor@debian.org>.  He
+rewrote most of it.
+
+Since May 20 2000, it is maintained by Roland Bauerschmidt
+<rb@debian.org>.
+
+Since March 24 2004, it is maintained by Roland Bauerschmidt
+<rb@debian.org>, and co-maintained by Marc Haber
+<mh+debian-packages@zugschlus.de>
+
+Since 23 Oct 2005, it has been maintained by Joerg Hoh <joerg@joerghoh.de> 
+
+Since June 2006, it has been maintained by Stephen Gran <sgran@debian.org>
+
+deluser is Copyright (C) 2000 Roland Bauerschmidt <rb@debian.org>
+and based on the source code of adduser.
+
+adduser is Copyright (C) 1997, 1998, 1999 Guy Maor <maor@debian.org>.
+adduser is Copyright (C) 1995 Ted Hajek <tedhajek@boombox.micro.umn.edu>
+with portions Copyright (C) 1994 Debian Association, Inc.
+
+The examples directory has been contributed by John Zaitseff, and is
+GPL V2 as well.
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the
+    Free Software Foundation, Inc.,
+    51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+
+On Debian GNU/Linux systems, the complete text of the GNU General
+Public License can be found in `/usr/share/common-licenses/GPL-2'.

--- a/analyzer/pkg/dpkg/testdata/copyrightFiles/usr/share/doc/apt/copyright
+++ b/analyzer/pkg/dpkg/testdata/copyrightFiles/usr/share/doc/apt/copyright
@@ -1,0 +1,22 @@
+Apt is copyright 1997, 1998, 1999 Jason Gunthorpe and others.
+Apt is currently developed by APT Development Team <deity@lists.debian.org>.
+
+License: GPLv2+
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+
+See /usr/share/common-licenses/GPL-2, or
+<http://www.gnu.org/copyleft/gpl.txt> for the terms of the latest version
+of the GNU General Public License.

--- a/analyzer/pkg/dpkg/testdata/copyrightFiles/usr/share/doc/tzdata/copyright
+++ b/analyzer/pkg/dpkg/testdata/copyrightFiles/usr/share/doc/tzdata/copyright
@@ -1,0 +1,10 @@
+This is the Debian prepackaged version of the Time Zone and Daylight 
+Saving Time Data. 
+
+It was downloaded from http://www.iana.org/time-zones
+
+Upstream Author: The Internet Assigned Numbers Authority (IANA)
+Commentary should be addressed to tz@iana.org
+
+Copyright: This database is in the public domain.
+

--- a/analyzer/pkg/dpkg/testdata/copyrightFiles/usr/share/doc/zlib1g/copyright
+++ b/analyzer/pkg/dpkg/testdata/copyrightFiles/usr/share/doc/zlib1g/copyright
@@ -1,0 +1,83 @@
+Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: zlib
+Upstream-Contact: zlib@gzip.org
+Source: http://zlib.net/
+Comment: This is the pre-packaged Debian Linux version of the zlib compression
+ library.  It was packaged by Michael Alan Dorman <mdorman@debian.org>
+ from sources originally retrieved from ftp.uu.net in the directory
+ /pub/archiving/zip/zlib as the file zlib-1.0.4.tar.gz.
+ .
+ The deflate format used by zlib was defined by Phil Katz. The deflate
+ and zlib specifications were written by Peter Deutsch. Thanks to all the
+ people who reported problems and suggested various improvements in zlib;
+ they are too numerous to cite here.
+Files-Excluded:
+ contrib/ada
+ contrib/amd64
+ contrib/asm686
+ contrib/blast
+ contrib/delphi
+ contrib/dotzlib
+ contrib/gcc_gvmat64
+ contrib/infback9
+ contrib/inflate86
+ contrib/iostream
+ contrib/iostream2
+ contrib/iostream3
+ contrib/masmx64
+ contrib/masmx86
+ contrib/pascal
+ contrib/puff
+ contrib/testzlib
+ contrib/untgz
+ contrib/vstudio
+ doc/rfc1950.txt
+ doc/rfc1951.txt
+ doc/rfc1952.txt
+
+Files: *
+Copyright: 1995-2013 Jean-loup Gailly and Mark Adler
+License: Zlib
+
+Files: amiga/Makefile.pup
+Copyright: 1998 by Andreas R. Kleinert
+License: Zlib
+
+Files: contrib/minizip/*
+Copyright: 1998-2010 Gilles Vollant
+           2007-2008 Even Rouault
+           2009-2010 Mathias Svensson
+License: Zlib
+
+Files: debian/*
+Copyright: 2000-2017 Mark Brown
+License: Zlib
+
+License: Zlib
+ This software is provided 'as-is', without any express or implied
+ warranty.  In no event will the authors be held liable for any damages
+ arising from the use of this software.
+ .
+ Permission is granted to anyone to use this software for any purpose,
+ including commercial applications, and to alter it and redistribute it
+ freely, subject to the following restrictions:
+ .
+ 1. The origin of this software must not be misrepresented; you must not
+    claim that you wrote the original software. If you use this software
+    in a product, an acknowledgment in the product documentation would be
+    appreciated but is not required.
+ 2. Altered source versions must be plainly marked as such, and must not be
+    misrepresented as being the original software.
+ 3. This notice may not be removed or altered from any source distribution.
+ .
+ Jean-loup Gailly        Mark Adler
+ jloup@gzip.org          madler@alumni.caltech.edu
+ .
+ If you use the zlib library in a product, we would appreciate *not* receiving
+ lengthy legal documents to sign.  The sources are provided for free but without
+ warranty of any kind.  The library has been entirely written by Jean-loup
+ Gailly and Mark Adler; it does not include third-party code.
+ .
+ If you redistribute modified sources, we would appreciate that you include in
+ the file ChangeLog history information documenting your changes.  Please read
+ the FAQ for more information on the distribution of modified source versions.

--- a/artifact/image/image_test.go
+++ b/artifact/image/image_test.go
@@ -3,6 +3,7 @@ package image_test
 import (
 	"context"
 	"errors"
+	"github.com/aquasecurity/fanal/analyzer/pkg/dpkg"
 	"testing"
 	"time"
 
@@ -46,17 +47,17 @@ func TestArtifact_Inspect(t *testing.T) {
 			missingBlobsExpectation: cache.ArtifactCacheMissingBlobsExpectation{
 				Args: cache.ArtifactCacheMissingBlobsArgs{
 					ArtifactID: "sha256:059741cfbdc039e88e337d621e57e03e99b0e0a75df32f2027ebef13f839af65",
-					BlobIDs:    []string{"sha256:4bfd231a20184276695bad3b02317ae33d6aea8e324ea3a14f4b395aebdbf00d"},
+					BlobIDs:    []string{"sha256:6cea8eb3648c3c5f03f71a7c05ef207eb10d73c3ce8d91229ea3576de7cb2d4a"},
 				},
 				Returns: cache.ArtifactCacheMissingBlobsReturns{
 					MissingArtifact: true,
-					MissingBlobIDs:  []string{"sha256:4bfd231a20184276695bad3b02317ae33d6aea8e324ea3a14f4b395aebdbf00d"},
+					MissingBlobIDs:  []string{"sha256:6cea8eb3648c3c5f03f71a7c05ef207eb10d73c3ce8d91229ea3576de7cb2d4a"},
 				},
 			},
 			putBlobExpectations: []cache.ArtifactCachePutBlobExpectation{
 				{
 					Args: cache.ArtifactCachePutBlobArgs{
-						BlobID: "sha256:4bfd231a20184276695bad3b02317ae33d6aea8e324ea3a14f4b395aebdbf00d",
+						BlobID: "sha256:6cea8eb3648c3c5f03f71a7c05ef207eb10d73c3ce8d91229ea3576de7cb2d4a",
 						BlobInfo: types.BlobInfo{
 							SchemaVersion: types.BlobJSONSchemaVersion,
 							Digest:        "",
@@ -110,7 +111,7 @@ func TestArtifact_Inspect(t *testing.T) {
 				Name:    "../../test/testdata/alpine-311.tar.gz",
 				Type:    types.ArtifactContainerImage,
 				ID:      "sha256:059741cfbdc039e88e337d621e57e03e99b0e0a75df32f2027ebef13f839af65",
-				BlobIDs: []string{"sha256:4bfd231a20184276695bad3b02317ae33d6aea8e324ea3a14f4b395aebdbf00d"},
+				BlobIDs: []string{"sha256:6cea8eb3648c3c5f03f71a7c05ef207eb10d73c3ce8d91229ea3576de7cb2d4a"},
 				ImageMetadata: types.ImageMetadata{
 					ID: "sha256:a187dde48cd289ac374ad8539930628314bc581a481cdb41409c9289419ddb72",
 					DiffIDs: []string{
@@ -164,25 +165,25 @@ func TestArtifact_Inspect(t *testing.T) {
 				Args: cache.ArtifactCacheMissingBlobsArgs{
 					ArtifactID: "sha256:a646bb11d39c149d4aaf9b888233048e0848304e5abd75667ea6f21d540d800c",
 					BlobIDs: []string{
-						"sha256:4642f2db3d5a26d45127906b6642898722eb10e34b07f981dd6d0f94c0b8bbbd",
-						"sha256:d86a65b160bbca0a07a0f95cd3229ea8ae1ee22e6a0aceb2171eaa10a31f9bd6",
-						"sha256:800b6042822f1ebeca709f280fc36f7d74c330e54c4d2a3663b474dab2555e31",
-						"sha256:ac38ac8691942ae24672640e05fa9a7f77ac4a3b6ce4c21a1b8399c039028851",
+						"sha256:b0b42727e5ee191f92d7fb9d9f2edfcfa716a04e7333a088026d0bacb9eb8a8c",
+						"sha256:926abb6a54f3d8b3fef7442364ddfe0c088e3515d14ea8cb9b583b1a30a2a4ba",
+						"sha256:690df4b838cd0fb846c2e9f2fc040b20205d839b38be2dc0f5ea8b8eb28acade",
+						"sha256:790775fb96b14a7148e78820367567780a803db94b5b90e4fe102e952f76c331",
 					},
 				},
 				Returns: cache.ArtifactCacheMissingBlobsReturns{
 					MissingBlobIDs: []string{
-						"sha256:4642f2db3d5a26d45127906b6642898722eb10e34b07f981dd6d0f94c0b8bbbd",
-						"sha256:d86a65b160bbca0a07a0f95cd3229ea8ae1ee22e6a0aceb2171eaa10a31f9bd6",
-						"sha256:800b6042822f1ebeca709f280fc36f7d74c330e54c4d2a3663b474dab2555e31",
-						"sha256:ac38ac8691942ae24672640e05fa9a7f77ac4a3b6ce4c21a1b8399c039028851",
+						"sha256:b0b42727e5ee191f92d7fb9d9f2edfcfa716a04e7333a088026d0bacb9eb8a8c",
+						"sha256:926abb6a54f3d8b3fef7442364ddfe0c088e3515d14ea8cb9b583b1a30a2a4ba",
+						"sha256:690df4b838cd0fb846c2e9f2fc040b20205d839b38be2dc0f5ea8b8eb28acade",
+						"sha256:790775fb96b14a7148e78820367567780a803db94b5b90e4fe102e952f76c331",
 					},
 				},
 			},
 			putBlobExpectations: []cache.ArtifactCachePutBlobExpectation{
 				{
 					Args: cache.ArtifactCachePutBlobArgs{
-						BlobID: "sha256:4642f2db3d5a26d45127906b6642898722eb10e34b07f981dd6d0f94c0b8bbbd",
+						BlobID: "sha256:b0b42727e5ee191f92d7fb9d9f2edfcfa716a04e7333a088026d0bacb9eb8a8c",
 						BlobInfo: types.BlobInfo{
 							SchemaVersion: types.BlobJSONSchemaVersion,
 							Digest:        "",
@@ -195,20 +196,42 @@ func TestArtifact_Inspect(t *testing.T) {
 								{
 									FilePath: "var/lib/dpkg/status.d/base",
 									Packages: []types.Package{
-										{Name: "base-files", Version: "9.9+deb9u9", SrcName: "base-files", SrcVersion: "9.9+deb9u9"},
+										{Name: "base-files", Version: "9.9+deb9u9", SrcName: "base-files", SrcVersion: "9.9+deb9u9", License: "GPL"},
 									},
 								},
 								{
 									FilePath: "var/lib/dpkg/status.d/netbase",
 									Packages: []types.Package{
-										{Name: "netbase", Version: "5.4", SrcName: "netbase", SrcVersion: "5.4"},
+										{Name: "netbase", Version: "5.4", SrcName: "netbase", SrcVersion: "5.4", License: "GPL-2"},
 									},
 								},
 								{
 									FilePath: "var/lib/dpkg/status.d/tzdata",
 									Packages: []types.Package{
-										{Name: "tzdata", Version: "2019a-0+deb9u1", SrcName: "tzdata", SrcVersion: "2019a-0+deb9u1"},
+										{Name: "tzdata", Version: "2019a-0+deb9u1", SrcName: "tzdata", SrcVersion: "2019a-0+deb9u1", License: "Unknown"},
 									},
+								},
+							},
+							CustomResources: []types.CustomResource{
+								{
+									Type:     dpkg.LicenseAdder,
+									FilePath: "base-files",
+									Data:     "GPL",
+								},
+								{
+									Type:     dpkg.LicenseAdder,
+									FilePath: "ca-certificates",
+									Data:     "GPL-2+, GPL-2, MPL-2.0, GPL-2.0",
+								},
+								{
+									Type:     dpkg.LicenseAdder,
+									FilePath: "netbase",
+									Data:     "GPL-2",
+								},
+								{
+									Type:     dpkg.LicenseAdder,
+									FilePath: "tzdata",
+									Data:     "Unknown",
 								},
 							},
 						},
@@ -216,7 +239,7 @@ func TestArtifact_Inspect(t *testing.T) {
 				},
 				{
 					Args: cache.ArtifactCachePutBlobArgs{
-						BlobID: "sha256:d86a65b160bbca0a07a0f95cd3229ea8ae1ee22e6a0aceb2171eaa10a31f9bd6",
+						BlobID: "sha256:926abb6a54f3d8b3fef7442364ddfe0c088e3515d14ea8cb9b583b1a30a2a4ba",
 						BlobInfo: types.BlobInfo{
 							SchemaVersion: types.BlobJSONSchemaVersion,
 							Digest:        "",
@@ -225,20 +248,37 @@ func TestArtifact_Inspect(t *testing.T) {
 								{
 									FilePath: "var/lib/dpkg/status.d/libc6",
 									Packages: []types.Package{
-										{Name: "libc6", Version: "2.24-11+deb9u4", SrcName: "glibc", SrcVersion: "2.24-11+deb9u4"},
+										{Name: "libc6", Version: "2.24-11+deb9u4", SrcName: "glibc", SrcVersion: "2.24-11+deb9u4", License: "LGPL-2.1, GPL-2, MIT, SunPro, BSD-3-Clause, GPL-2.0, ISC, LicenseRef-MIT-Lucent"},
 									},
 								},
 								{
 									FilePath: "var/lib/dpkg/status.d/libssl1",
 									Packages: []types.Package{
-										{Name: "libssl1.1", Version: "1.1.0k-1~deb9u1", SrcName: "openssl", SrcVersion: "1.1.0k-1~deb9u1"},
+										{Name: "libssl1.1", Version: "1.1.0k-1~deb9u1", SrcName: "openssl", SrcVersion: "1.1.0k-1~deb9u1", License: "OpenSSL"},
 									},
 								},
 								{
 									FilePath: "var/lib/dpkg/status.d/openssl",
 									Packages: []types.Package{
-										{Name: "openssl", Version: "1.1.0k-1~deb9u1", SrcName: "openssl", SrcVersion: "1.1.0k-1~deb9u1"},
+										{Name: "openssl", Version: "1.1.0k-1~deb9u1", SrcName: "openssl", SrcVersion: "1.1.0k-1~deb9u1", License: "OpenSSL"},
 									},
+								},
+							},
+							CustomResources: []types.CustomResource{
+								{
+									Type:     dpkg.LicenseAdder,
+									FilePath: "libc6",
+									Data:     "LGPL-2.1, GPL-2, MIT, SunPro, BSD-3-Clause, GPL-2.0, ISC, LicenseRef-MIT-Lucent",
+								},
+								{
+									Type:     dpkg.LicenseAdder,
+									FilePath: "libssl1.1",
+									Data:     "OpenSSL",
+								},
+								{
+									Type:     dpkg.LicenseAdder,
+									FilePath: "openssl",
+									Data:     "OpenSSL",
 								},
 							},
 						},
@@ -246,7 +286,7 @@ func TestArtifact_Inspect(t *testing.T) {
 				},
 				{
 					Args: cache.ArtifactCachePutBlobArgs{
-						BlobID: "sha256:800b6042822f1ebeca709f280fc36f7d74c330e54c4d2a3663b474dab2555e31",
+						BlobID: "sha256:690df4b838cd0fb846c2e9f2fc040b20205d839b38be2dc0f5ea8b8eb28acade",
 						BlobInfo: types.BlobInfo{
 							SchemaVersion: types.BlobJSONSchemaVersion,
 							Digest:        "",
@@ -275,7 +315,7 @@ func TestArtifact_Inspect(t *testing.T) {
 				},
 				{
 					Args: cache.ArtifactCachePutBlobArgs{
-						BlobID: "sha256:ac38ac8691942ae24672640e05fa9a7f77ac4a3b6ce4c21a1b8399c039028851",
+						BlobID: "sha256:790775fb96b14a7148e78820367567780a803db94b5b90e4fe102e952f76c331",
 						BlobInfo: types.BlobInfo{
 							SchemaVersion: types.BlobJSONSchemaVersion,
 							Digest:        "",
@@ -350,10 +390,10 @@ func TestArtifact_Inspect(t *testing.T) {
 				Type: types.ArtifactContainerImage,
 				ID:   "sha256:a646bb11d39c149d4aaf9b888233048e0848304e5abd75667ea6f21d540d800c",
 				BlobIDs: []string{
-					"sha256:4642f2db3d5a26d45127906b6642898722eb10e34b07f981dd6d0f94c0b8bbbd",
-					"sha256:d86a65b160bbca0a07a0f95cd3229ea8ae1ee22e6a0aceb2171eaa10a31f9bd6",
-					"sha256:800b6042822f1ebeca709f280fc36f7d74c330e54c4d2a3663b474dab2555e31",
-					"sha256:ac38ac8691942ae24672640e05fa9a7f77ac4a3b6ce4c21a1b8399c039028851",
+					"sha256:b0b42727e5ee191f92d7fb9d9f2edfcfa716a04e7333a088026d0bacb9eb8a8c",
+					"sha256:926abb6a54f3d8b3fef7442364ddfe0c088e3515d14ea8cb9b583b1a30a2a4ba",
+					"sha256:690df4b838cd0fb846c2e9f2fc040b20205d839b38be2dc0f5ea8b8eb28acade",
+					"sha256:790775fb96b14a7148e78820367567780a803db94b5b90e4fe102e952f76c331",
 				},
 				ImageMetadata: types.ImageMetadata{
 					ID: "sha256:58701fd185bda36cab0557bb6438661831267aa4a9e0b54211c4d5317a48aff4",
@@ -433,25 +473,25 @@ func TestArtifact_Inspect(t *testing.T) {
 				Args: cache.ArtifactCacheMissingBlobsArgs{
 					ArtifactID: "sha256:a646bb11d39c149d4aaf9b888233048e0848304e5abd75667ea6f21d540d800c",
 					BlobIDs: []string{
-						"sha256:f67d93fd2119599482561b1cbfd8b814a7cf122084fd631e429d8afa0825c0da",
-						"sha256:5cbd70da9cff82931bbc5961b647ce45b60988ec245bc48c01a70fdd808bd632",
-						"sha256:06769fb393db49224c32414662f5333bb874d2ff72914afce82286af149a3818",
-						"sha256:5fbc1da11f2bb1b5ebc43e3c92e963b7d5da43f627801a54bd95a4658e30b7f7",
+						"sha256:335f12317950be53999020d6ae23f2612d362eee958f02bcb30cee56264362d2",
+						"sha256:1eb81146df23f98031c2fb8c020749649b13bd99360d9571dd19c854a2a576a5",
+						"sha256:fdda788e41ad3aaed4e9da2ce7619e23d19bbe4e04a5aa5a6e9fdff63170cc72",
+						"sha256:244fa01dfafb9a0fe2cb807e0d442af67abfc36619673435ef68778028f08020",
 					},
 				},
 				Returns: cache.ArtifactCacheMissingBlobsReturns{
 					MissingBlobIDs: []string{
-						"sha256:f67d93fd2119599482561b1cbfd8b814a7cf122084fd631e429d8afa0825c0da",
-						"sha256:5cbd70da9cff82931bbc5961b647ce45b60988ec245bc48c01a70fdd808bd632",
-						"sha256:06769fb393db49224c32414662f5333bb874d2ff72914afce82286af149a3818",
-						"sha256:5fbc1da11f2bb1b5ebc43e3c92e963b7d5da43f627801a54bd95a4658e30b7f7",
+						"sha256:335f12317950be53999020d6ae23f2612d362eee958f02bcb30cee56264362d2",
+						"sha256:1eb81146df23f98031c2fb8c020749649b13bd99360d9571dd19c854a2a576a5",
+						"sha256:fdda788e41ad3aaed4e9da2ce7619e23d19bbe4e04a5aa5a6e9fdff63170cc72",
+						"sha256:244fa01dfafb9a0fe2cb807e0d442af67abfc36619673435ef68778028f08020",
 					},
 				},
 			},
 			putBlobExpectations: []cache.ArtifactCachePutBlobExpectation{
 				{
 					Args: cache.ArtifactCachePutBlobArgs{
-						BlobID: "sha256:f67d93fd2119599482561b1cbfd8b814a7cf122084fd631e429d8afa0825c0da",
+						BlobID: "sha256:335f12317950be53999020d6ae23f2612d362eee958f02bcb30cee56264362d2",
 						BlobInfo: types.BlobInfo{
 							SchemaVersion: types.BlobJSONSchemaVersion,
 							Digest:        "",
@@ -461,7 +501,7 @@ func TestArtifact_Inspect(t *testing.T) {
 				},
 				{
 					Args: cache.ArtifactCachePutBlobArgs{
-						BlobID: "sha256:5cbd70da9cff82931bbc5961b647ce45b60988ec245bc48c01a70fdd808bd632",
+						BlobID: "sha256:1eb81146df23f98031c2fb8c020749649b13bd99360d9571dd19c854a2a576a5",
 						BlobInfo: types.BlobInfo{
 							SchemaVersion: types.BlobJSONSchemaVersion,
 							Digest:        "",
@@ -471,7 +511,7 @@ func TestArtifact_Inspect(t *testing.T) {
 				},
 				{
 					Args: cache.ArtifactCachePutBlobArgs{
-						BlobID: "sha256:06769fb393db49224c32414662f5333bb874d2ff72914afce82286af149a3818",
+						BlobID: "sha256:fdda788e41ad3aaed4e9da2ce7619e23d19bbe4e04a5aa5a6e9fdff63170cc72",
 						BlobInfo: types.BlobInfo{
 							SchemaVersion: types.BlobJSONSchemaVersion,
 							Digest:        "",
@@ -482,7 +522,7 @@ func TestArtifact_Inspect(t *testing.T) {
 				},
 				{
 					Args: cache.ArtifactCachePutBlobArgs{
-						BlobID: "sha256:5fbc1da11f2bb1b5ebc43e3c92e963b7d5da43f627801a54bd95a4658e30b7f7",
+						BlobID: "sha256:244fa01dfafb9a0fe2cb807e0d442af67abfc36619673435ef68778028f08020",
 						BlobInfo: types.BlobInfo{
 							SchemaVersion: types.BlobJSONSchemaVersion,
 							Digest:        "",
@@ -497,10 +537,10 @@ func TestArtifact_Inspect(t *testing.T) {
 				Type: types.ArtifactContainerImage,
 				ID:   "sha256:a646bb11d39c149d4aaf9b888233048e0848304e5abd75667ea6f21d540d800c",
 				BlobIDs: []string{
-					"sha256:f67d93fd2119599482561b1cbfd8b814a7cf122084fd631e429d8afa0825c0da",
-					"sha256:5cbd70da9cff82931bbc5961b647ce45b60988ec245bc48c01a70fdd808bd632",
-					"sha256:06769fb393db49224c32414662f5333bb874d2ff72914afce82286af149a3818",
-					"sha256:5fbc1da11f2bb1b5ebc43e3c92e963b7d5da43f627801a54bd95a4658e30b7f7",
+					"sha256:335f12317950be53999020d6ae23f2612d362eee958f02bcb30cee56264362d2",
+					"sha256:1eb81146df23f98031c2fb8c020749649b13bd99360d9571dd19c854a2a576a5",
+					"sha256:fdda788e41ad3aaed4e9da2ce7619e23d19bbe4e04a5aa5a6e9fdff63170cc72",
+					"sha256:244fa01dfafb9a0fe2cb807e0d442af67abfc36619673435ef68778028f08020",
 				},
 				ImageMetadata: types.ImageMetadata{
 					ID: "sha256:58701fd185bda36cab0557bb6438661831267aa4a9e0b54211c4d5317a48aff4",
@@ -580,7 +620,7 @@ func TestArtifact_Inspect(t *testing.T) {
 			missingBlobsExpectation: cache.ArtifactCacheMissingBlobsExpectation{
 				Args: cache.ArtifactCacheMissingBlobsArgs{
 					ArtifactID: "sha256:059741cfbdc039e88e337d621e57e03e99b0e0a75df32f2027ebef13f839af65",
-					BlobIDs:    []string{"sha256:4bfd231a20184276695bad3b02317ae33d6aea8e324ea3a14f4b395aebdbf00d"},
+					BlobIDs:    []string{"sha256:6cea8eb3648c3c5f03f71a7c05ef207eb10d73c3ce8d91229ea3576de7cb2d4a"},
 				},
 				Returns: cache.ArtifactCacheMissingBlobsReturns{
 					Err: xerrors.New("MissingBlobs failed"),
@@ -594,16 +634,16 @@ func TestArtifact_Inspect(t *testing.T) {
 			missingBlobsExpectation: cache.ArtifactCacheMissingBlobsExpectation{
 				Args: cache.ArtifactCacheMissingBlobsArgs{
 					ArtifactID: "sha256:059741cfbdc039e88e337d621e57e03e99b0e0a75df32f2027ebef13f839af65",
-					BlobIDs:    []string{"sha256:4bfd231a20184276695bad3b02317ae33d6aea8e324ea3a14f4b395aebdbf00d"},
+					BlobIDs:    []string{"sha256:6cea8eb3648c3c5f03f71a7c05ef207eb10d73c3ce8d91229ea3576de7cb2d4a"},
 				},
 				Returns: cache.ArtifactCacheMissingBlobsReturns{
-					MissingBlobIDs: []string{"sha256:4bfd231a20184276695bad3b02317ae33d6aea8e324ea3a14f4b395aebdbf00d"},
+					MissingBlobIDs: []string{"sha256:6cea8eb3648c3c5f03f71a7c05ef207eb10d73c3ce8d91229ea3576de7cb2d4a"},
 				},
 			},
 			putBlobExpectations: []cache.ArtifactCachePutBlobExpectation{
 				{
 					Args: cache.ArtifactCachePutBlobArgs{
-						BlobID: "sha256:4bfd231a20184276695bad3b02317ae33d6aea8e324ea3a14f4b395aebdbf00d",
+						BlobID: "sha256:6cea8eb3648c3c5f03f71a7c05ef207eb10d73c3ce8d91229ea3576de7cb2d4a",
 						BlobInfo: types.BlobInfo{
 							SchemaVersion: types.BlobJSONSchemaVersion,
 							Digest:        "",
@@ -649,17 +689,17 @@ func TestArtifact_Inspect(t *testing.T) {
 			missingBlobsExpectation: cache.ArtifactCacheMissingBlobsExpectation{
 				Args: cache.ArtifactCacheMissingBlobsArgs{
 					ArtifactID: "sha256:059741cfbdc039e88e337d621e57e03e99b0e0a75df32f2027ebef13f839af65",
-					BlobIDs:    []string{"sha256:4bfd231a20184276695bad3b02317ae33d6aea8e324ea3a14f4b395aebdbf00d"},
+					BlobIDs:    []string{"sha256:6cea8eb3648c3c5f03f71a7c05ef207eb10d73c3ce8d91229ea3576de7cb2d4a"},
 				},
 				Returns: cache.ArtifactCacheMissingBlobsReturns{
 					MissingArtifact: true,
-					MissingBlobIDs:  []string{"sha256:4bfd231a20184276695bad3b02317ae33d6aea8e324ea3a14f4b395aebdbf00d"},
+					MissingBlobIDs:  []string{"sha256:6cea8eb3648c3c5f03f71a7c05ef207eb10d73c3ce8d91229ea3576de7cb2d4a"},
 				},
 			},
 			putBlobExpectations: []cache.ArtifactCachePutBlobExpectation{
 				{
 					Args: cache.ArtifactCachePutBlobArgs{
-						BlobID: "sha256:4bfd231a20184276695bad3b02317ae33d6aea8e324ea3a14f4b395aebdbf00d",
+						BlobID: "sha256:6cea8eb3648c3c5f03f71a7c05ef207eb10d73c3ce8d91229ea3576de7cb2d4a",
 						BlobInfo: types.BlobInfo{
 							SchemaVersion: types.BlobJSONSchemaVersion,
 							Digest:        "",

--- a/artifact/local/fs.go
+++ b/artifact/local/fs.go
@@ -124,6 +124,7 @@ func (a Artifact) Inspect(ctx context.Context) (types.ArtifactReference, error) 
 		Applications:      result.Applications,
 		Misconfigurations: misconfs,
 		SystemFiles:       result.SystemInstalledFiles,
+		CustomResources:   result.CustomResources,
 	}
 
 	if err = a.hookManager.CallHooks(&blobInfo); err != nil {

--- a/artifact/local/fs_test.go
+++ b/artifact/local/fs_test.go
@@ -43,7 +43,7 @@ func TestArtifact_Inspect(t *testing.T) {
 			},
 			putBlobExpectation: cache.ArtifactCachePutBlobExpectation{
 				Args: cache.ArtifactCachePutBlobArgs{
-					BlobID: "sha256:566841e0f2bc23a761706c8dae1cd4ddda8ac6a013026a059f21a2cc748b5206",
+					BlobID: "sha256:7394e6119cef3213553f874470f0871b51cd332446a98a2549c557e490bf5af4",
 					BlobInfo: types.BlobInfo{
 						SchemaVersion: types.BlobJSONSchemaVersion,
 						DiffID:        "sha256:9eaa33f9952218e93b2b7678e0092c5eb809877c948af5ea19b5148c5857d9fa",
@@ -66,9 +66,9 @@ func TestArtifact_Inspect(t *testing.T) {
 			want: types.ArtifactReference{
 				Name: "host",
 				Type: types.ArtifactFilesystem,
-				ID:   "sha256:566841e0f2bc23a761706c8dae1cd4ddda8ac6a013026a059f21a2cc748b5206",
+				ID:   "sha256:7394e6119cef3213553f874470f0871b51cd332446a98a2549c557e490bf5af4",
 				BlobIDs: []string{
-					"sha256:566841e0f2bc23a761706c8dae1cd4ddda8ac6a013026a059f21a2cc748b5206",
+					"sha256:7394e6119cef3213553f874470f0871b51cd332446a98a2549c557e490bf5af4",
 				},
 			},
 		},
@@ -82,7 +82,7 @@ func TestArtifact_Inspect(t *testing.T) {
 			},
 			putBlobExpectation: cache.ArtifactCachePutBlobExpectation{
 				Args: cache.ArtifactCachePutBlobArgs{
-					BlobID: "sha256:c7edf2dea9d30af500d593ab40cac2615d92f569929299e7517948f7b5466c19",
+					BlobID: "sha256:6da384b2644fe569b780f572d5aa9a5ab8593cb1a8c59987cfbec4f25af1ff73",
 					BlobInfo: types.BlobInfo{
 						SchemaVersion: types.BlobJSONSchemaVersion,
 						DiffID:        "sha256:8ad5ef100e762e3f4df37beb3f8231a782cea12ad9d39bda13fd5850d1b15d11",
@@ -93,9 +93,9 @@ func TestArtifact_Inspect(t *testing.T) {
 			want: types.ArtifactReference{
 				Name: "host",
 				Type: types.ArtifactFilesystem,
-				ID:   "sha256:c7edf2dea9d30af500d593ab40cac2615d92f569929299e7517948f7b5466c19",
+				ID:   "sha256:6da384b2644fe569b780f572d5aa9a5ab8593cb1a8c59987cfbec4f25af1ff73",
 				BlobIDs: []string{
-					"sha256:c7edf2dea9d30af500d593ab40cac2615d92f569929299e7517948f7b5466c19",
+					"sha256:6da384b2644fe569b780f572d5aa9a5ab8593cb1a8c59987cfbec4f25af1ff73",
 				},
 			},
 		},
@@ -106,7 +106,7 @@ func TestArtifact_Inspect(t *testing.T) {
 			},
 			putBlobExpectation: cache.ArtifactCachePutBlobExpectation{
 				Args: cache.ArtifactCachePutBlobArgs{
-					BlobID: "sha256:566841e0f2bc23a761706c8dae1cd4ddda8ac6a013026a059f21a2cc748b5206",
+					BlobID: "sha256:7394e6119cef3213553f874470f0871b51cd332446a98a2549c557e490bf5af4",
 					BlobInfo: types.BlobInfo{
 						SchemaVersion: types.BlobJSONSchemaVersion,
 						DiffID:        "sha256:9eaa33f9952218e93b2b7678e0092c5eb809877c948af5ea19b5148c5857d9fa",
@@ -144,7 +144,7 @@ func TestArtifact_Inspect(t *testing.T) {
 			},
 			putBlobExpectation: cache.ArtifactCachePutBlobExpectation{
 				Args: cache.ArtifactCachePutBlobArgs{
-					BlobID: "sha256:4750c846cf79661482e71dfc0a89b16463cda5c53c62d5885acaa874056f8b92",
+					BlobID: "sha256:3cabeb80e94b6818d98c14e1799d7398c4f5f700e168e1fc371814008c03458e",
 					BlobInfo: types.BlobInfo{
 						SchemaVersion: types.BlobJSONSchemaVersion,
 						DiffID:        "sha256:de52b03af926ba8f646bd11b794f014161b11a3dbad0213d556ea9af120e1623",
@@ -167,9 +167,9 @@ func TestArtifact_Inspect(t *testing.T) {
 			want: types.ArtifactReference{
 				Name: "testdata/requirements.txt",
 				Type: types.ArtifactFilesystem,
-				ID:   "sha256:4750c846cf79661482e71dfc0a89b16463cda5c53c62d5885acaa874056f8b92",
+				ID:   "sha256:3cabeb80e94b6818d98c14e1799d7398c4f5f700e168e1fc371814008c03458e",
 				BlobIDs: []string{
-					"sha256:4750c846cf79661482e71dfc0a89b16463cda5c53c62d5885acaa874056f8b92",
+					"sha256:3cabeb80e94b6818d98c14e1799d7398c4f5f700e168e1fc371814008c03458e",
 				},
 			},
 		},
@@ -180,7 +180,7 @@ func TestArtifact_Inspect(t *testing.T) {
 			},
 			putBlobExpectation: cache.ArtifactCachePutBlobExpectation{
 				Args: cache.ArtifactCachePutBlobArgs{
-					BlobID: "sha256:4750c846cf79661482e71dfc0a89b16463cda5c53c62d5885acaa874056f8b92",
+					BlobID: "sha256:3cabeb80e94b6818d98c14e1799d7398c4f5f700e168e1fc371814008c03458e",
 					BlobInfo: types.BlobInfo{
 						SchemaVersion: types.BlobJSONSchemaVersion,
 						DiffID:        "sha256:de52b03af926ba8f646bd11b794f014161b11a3dbad0213d556ea9af120e1623",
@@ -203,9 +203,9 @@ func TestArtifact_Inspect(t *testing.T) {
 			want: types.ArtifactReference{
 				Name: "testdata/requirements.txt",
 				Type: types.ArtifactFilesystem,
-				ID:   "sha256:4750c846cf79661482e71dfc0a89b16463cda5c53c62d5885acaa874056f8b92",
+				ID:   "sha256:3cabeb80e94b6818d98c14e1799d7398c4f5f700e168e1fc371814008c03458e",
 				BlobIDs: []string{
-					"sha256:4750c846cf79661482e71dfc0a89b16463cda5c53c62d5885acaa874056f8b92",
+					"sha256:3cabeb80e94b6818d98c14e1799d7398c4f5f700e168e1fc371814008c03458e",
 				},
 			},
 		},

--- a/artifact/remote/git_test.go
+++ b/artifact/remote/git_test.go
@@ -108,9 +108,9 @@ func TestArtifact_Inspect(t *testing.T) {
 			want: types.ArtifactReference{
 				Name: ts.URL + "/test.git",
 				Type: types.ArtifactRemoteRepository,
-				ID:   "sha256:8dd3e15371c90ab4efcc15dea5c8cc1fac9a8c273c5208ad25a562074fd099cc",
+				ID:   "sha256:ee3b0539d70853ad31fee65c1492743db0331fee26b12888e031fcc7d29b15cc",
 				BlobIDs: []string{
-					"sha256:8dd3e15371c90ab4efcc15dea5c8cc1fac9a8c273c5208ad25a562074fd099cc",
+					"sha256:ee3b0539d70853ad31fee65c1492743db0331fee26b12888e031fcc7d29b15cc",
 				},
 			},
 		},

--- a/go.mod
+++ b/go.mod
@@ -95,6 +95,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.2.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/licenseclassifier/v2 v2.0.0-pre5 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.1.1 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -751,6 +751,8 @@ github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSN
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/licenseclassifier/v2 v2.0.0-pre5 h1:glsMqvBI3S7ZZ58FGrEZubz+0W6N/8MJS5HYVWxZH3M=
+github.com/google/licenseclassifier/v2 v2.0.0-pre5/go.mod h1:cOjbdH0kyC9R22sdQbYsFkto4NGCAc+ZSwbeThazEtM=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian v2.1.1-0.20190517191504-25dcb96d9e51+incompatible h1:xmapqc1AyLoB+ddYT6r04bD9lIjlOqGaREovi0SzFaE=
 github.com/google/martian v2.1.1-0.20190517191504-25dcb96d9e51+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=

--- a/hook/all/import.go
+++ b/hook/all/import.go
@@ -1,5 +1,6 @@
 package all
 
 import (
+	_ "github.com/aquasecurity/fanal/hook/dpkg"
 	_ "github.com/aquasecurity/fanal/hook/filter"
 )

--- a/hook/dpkg/licenseadder.go
+++ b/hook/dpkg/licenseadder.go
@@ -1,0 +1,53 @@
+package dpkg
+
+import (
+	"github.com/aquasecurity/fanal/analyzer/pkg/dpkg"
+	"github.com/aquasecurity/fanal/hook"
+	"github.com/aquasecurity/fanal/types"
+)
+
+func init() {
+	hook.RegisterHook(dpkgLicenseHook{})
+}
+
+const version = 1
+
+type dpkgLicenseHook struct{}
+
+// Hook add licenses to dpkg files
+func (h dpkgLicenseHook) Hook(blob *types.BlobInfo) error {
+	licenses := map[string]string{}
+	for _, resource := range blob.CustomResources {
+		if resource.Type == dpkg.LicenseAdder {
+			licenses[resource.FilePath] = resource.Data.(string)
+		}
+
+	}
+
+	var infos []types.PackageInfo
+	for _, pkgInfo := range blob.PackageInfos {
+
+		var packages []types.Package
+		for _, pkg := range pkgInfo.Packages {
+			license, ok := licenses[pkg.Name]
+			if ok {
+				pkg.License = license
+			}
+			packages = append(packages, pkg)
+		}
+
+		pkgInfo.Packages = packages
+		infos = append(infos, pkgInfo)
+	}
+
+	blob.PackageInfos = infos
+	return nil
+}
+
+func (h dpkgLicenseHook) Version() int {
+	return version
+}
+
+func (h dpkgLicenseHook) Type() hook.Type {
+	return hook.DpkgLicenseAdder
+}

--- a/hook/types.go
+++ b/hook/types.go
@@ -1,5 +1,7 @@
 package hook
 
+import "github.com/aquasecurity/fanal/analyzer/pkg/dpkg"
+
 type Type string
 
 const (
@@ -8,4 +10,6 @@ const (
 	GemSpec   Type = "gemspec"
 
 	SystemFileFilter Type = "system-file-filter"
+
+	DpkgLicenseAdder Type = dpkg.LicenseAdder
 )


### PR DESCRIPTION
## Description
Debian based system hasn't requirement to write license information.
But almost every package in Debian contains a copyright file in `/usr/share/doc/<packagename>/copyright`.
More information [here](https://github.com/daald/dpkg-licenses).

Added parser for copyright files and hook for adding licenses to dpkgs.

For parsing copyright files used:
- `License: *` pattern.
- Parse common license url.
- [licenseclassifier](https://github.com/google/licenseclassifier)