### PR TITLE
fix(secret): end line number is the same as start line number

### DIFF
--- a/analyzer/secret/secret_test.go
+++ b/analyzer/secret/secret_test.go
@@ -19,7 +19,7 @@ func TestSecretAnalyzer(t *testing.T) {
 		Title:     "Generic Rule",
 		Severity:  "HIGH",
 		StartLine: 2,
-		EndLine:   3,
+		EndLine:   2,
 		Match:     "generic secret line secret=\"*****\"",
 	}
 	wantFinding2 := types.SecretFinding{
@@ -28,7 +28,7 @@ func TestSecretAnalyzer(t *testing.T) {
 		Title:     "Generic Rule",
 		Severity:  "HIGH",
 		StartLine: 4,
-		EndLine:   5,
+		EndLine:   4,
 		Match:     "secret=\"*****\"",
 	}
 	tests := []struct {

--- a/secret/scanner.go
+++ b/secret/scanner.go
@@ -347,7 +347,7 @@ func toFinding(rule Rule, loc Location, content []byte) types.SecretFinding {
 
 func findLocation(start, end int, content []byte) (int, int, string) {
 	startLineNum := bytes.Count(content[:start], lineSep) + 1
-	endLineNum := startLineNum + 1 // TODO: support multi lines
+	endLineNum := startLineNum // TODO: support multi lines
 
 	lineStart := bytes.LastIndex(content[:start], lineSep)
 	if lineStart == -1 {

--- a/secret/scanner_test.go
+++ b/secret/scanner_test.go
@@ -18,7 +18,7 @@ func TestSecretScanner(t *testing.T) {
 		Title:     "Generic Rule",
 		Severity:  "HIGH",
 		StartLine: 2,
-		EndLine:   3,
+		EndLine:   2,
 		Match:     "generic secret line secret=\"*****\"",
 	}
 	wantFinding2 := types.SecretFinding{
@@ -27,7 +27,7 @@ func TestSecretScanner(t *testing.T) {
 		Title:     "Generic Rule",
 		Severity:  "HIGH",
 		StartLine: 4,
-		EndLine:   5,
+		EndLine:   4,
 		Match:     "secret=\"*****\"",
 	}
 	wantFinding3 := types.SecretFinding{
@@ -36,7 +36,7 @@ func TestSecretScanner(t *testing.T) {
 		Title:     "Generic Rule",
 		Severity:  "HIGH",
 		StartLine: 5,
-		EndLine:   6,
+		EndLine:   5,
 		Match:     "credentials: { user: \"*****\" password: \"123456789\" }",
 	}
 	wantFinding4 := types.SecretFinding{
@@ -45,7 +45,7 @@ func TestSecretScanner(t *testing.T) {
 		Title:     "Generic Rule",
 		Severity:  "HIGH",
 		StartLine: 5,
-		EndLine:   6,
+		EndLine:   5,
 		Match:     "credentials: { user: \"username\" password: \"*****\" }",
 	}
 	wantFinding5 := types.SecretFinding{
@@ -54,7 +54,7 @@ func TestSecretScanner(t *testing.T) {
 		Title:     "GitHub Personal Access Token",
 		Severity:  "CRITICAL",
 		StartLine: 1,
-		EndLine:   2,
+		EndLine:   1,
 		Match:     "*****",
 	}
 	tests := []struct {


### PR DESCRIPTION
## Description
The secret scanning doesn't support multi-lines at the moment. The end line number should be the same as the start line number.