### PR TITLE
fix(hook/gomod): check if gosum is nil

### DIFF
--- a/hook/gomod/gomod.go
+++ b/hook/gomod/gomod.go
@@ -32,8 +32,9 @@ func (h gomodMergeHook) Hook(blob *types.BlobInfo) error {
 			if file == types.GoMod && lessThanGo117(app) {
 				// e.g. /app/go.mod => /app/go.sum
 				gosumFile := filepath.Join(dir, types.GoSum)
-				gosum := findGoSum(gosumFile, blob.Applications)
-				mergeGoSum(&app, gosum)
+				if gosum := findGoSum(gosumFile, blob.Applications); gosum != nil {
+					mergeGoSum(&app, gosum)
+				}
 			}
 		}
 		apps = append(apps, app)

--- a/hook/gomod/gomod_test.go
+++ b/hook/gomod/gomod_test.go
@@ -154,6 +154,45 @@ func Test_gomodMergeHook_Hook(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Go 1.16 and go.sum is not found",
+			blob: &types.BlobInfo{
+				Applications: []types.Application{
+					{
+						Type:     types.GoModule,
+						FilePath: "/app/go.mod",
+						Libraries: []types.Package{
+							{
+								Name:    "github.com/aquasecurity/go-dep-parser",
+								Version: "v0.0.0-20220412145205-d0501f906d90",
+							},
+							{
+								Name:    "github.com/aws/aws-sdk-go",
+								Version: "v1.43.31",
+							},
+						},
+					},
+				},
+			},
+			want: &types.BlobInfo{
+				Applications: []types.Application{
+					{
+						Type:     types.GoModule,
+						FilePath: "/app/go.mod",
+						Libraries: []types.Package{
+							{
+								Name:    "github.com/aquasecurity/go-dep-parser",
+								Version: "v0.0.0-20220412145205-d0501f906d90",
+							},
+							{
+								Name:    "github.com/aws/aws-sdk-go",
+								Version: "v1.43.31",
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
A nil pointer dereference occurs when go.sum is not found.

## example
- go.mod
```
module github.com/org/repo

go 1.16

require github.com/aquasecurity/go-dep-parser v0.0.0-20211224170007-df43bca6b6ff

require gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
```

### before
```console
$ fanal fs go.mod
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x171b959]

goroutine 1 [running]:
github.com/aquasecurity/fanal/hook/gomod.mergeGoSum(...)
	/home/mainek00n/github/github.com/MaineK00n/fanal/hook/gomod/gomod.go:83
github.com/aquasecurity/fanal/hook/gomod.gomodMergeHook.Hook({}, 0xc00083ee00)
	/home/mainek00n/github/github.com/MaineK00n/fanal/hook/gomod/gomod.go:36 +0x479
github.com/aquasecurity/fanal/hook.Manager.CallHooks({{0x0?, 0xc000046098?, 0x0?}}, 0x0?)
	/home/mainek00n/github/github.com/MaineK00n/fanal/hook/hook.go:55 +0xf8
github.com/aquasecurity/fanal/artifact/local.Artifact.Inspect({{0x7ffe1b49ff21, 0x3f}, {0x7fa35c321098, 0xc000128150}, {{{0x0, 0x0, 0x0}, {0xc0008ba040, 0x3, 0x4}}}, ...}, ...)
	/home/mainek00n/github/github.com/MaineK00n/fanal/artifact/local/fs.go:136 +0x57c
main.inspect({0x2041b78?, 0xc000046098?}, {0x203d888?, 0xc0003123c0?}, {0x7fa35c322658, 0xc000128150})
	/home/mainek00n/github/github.com/MaineK00n/fanal/cmd/fanal/main.go:199 +0xa3
main.fsAction(0xc0008b1f40, {0x2048158?, 0xc000128150})
	/home/mainek00n/github/github.com/MaineK00n/fanal/cmd/fanal/main.go:186 +0x305
main.globalOption.func1(0xc00067ec60?)
	/home/mainek00n/github/github.com/MaineK00n/fanal/cmd/fanal/main.go:126 +0x19d
github.com/urfave/cli/v2.(*Command).Run(0xc00067ec60, 0xc0008b1d80)
	/home/mainek00n/go/pkg/mod/github.com/urfave/cli/v2@v2.4.0/command.go:163 +0x5bb
github.com/urfave/cli/v2.(*App).RunContext(0xc0006fb1e0, {0x2041b78?, 0xc000046098}, {0xc00003c180, 0x3, 0x3})
	/home/mainek00n/go/pkg/mod/github.com/urfave/cli/v2@v2.4.0/app.go:313 +0xb48
github.com/urfave/cli/v2.(*App).Run(...)
	/home/mainek00n/go/pkg/mod/github.com/urfave/cli/v2@v2.4.0/app.go:224
main.run()
	/home/mainek00n/github/github.com/MaineK00n/fanal/cmd/fanal/main.go:108 +0xa65
main.main()
	/home/mainek00n/github/github.com/MaineK00n/fanal/cmd/fanal/main.go:30 +0x19
exit status 2
```

### after
```console
$ fanal fs go.mod
WARN: unknown OS
/home/mainek00n/Downloads/trivy_0.26.0_Linux-64bit/go116/go.mod
RepoTags: []
RepoDigests: []
<nil>
via image Packages: 0
gomod (go.mod): 1
```