### PR TITLE
refactor(secret): allow list match with secret subgroups

### DIFF
--- a/secret/builtin-allow-rules.go
+++ b/secret/builtin-allow-rules.go
@@ -3,7 +3,7 @@ package secret
 var builtinAllowRules = []AllowRule{
 	{
 		ID:          "tests",
-		Description: "Avoid paths containing test",
+		Description: "Avoid test files and paths",
 		Path:        MustCompile(`(\/test|-test|_test|\.test)`),
 	},
 	{

--- a/secret/builtin-allow-rules.go
+++ b/secret/builtin-allow-rules.go
@@ -19,7 +19,7 @@ var builtinAllowRules = []AllowRule{
 	{
 		ID:          "locale-dir",
 		Description: "Locales directory contains locales file",
-		Path:        MustCompile(`\/locale\/`),
+		Path:        MustCompile(`\/locales?\/`),
 	},
 	{
 		ID:          "markdown",

--- a/secret/builtin-allow-rules.go
+++ b/secret/builtin-allow-rules.go
@@ -4,7 +4,7 @@ var builtinAllowRules = []AllowRule{
 	{
 		ID:          "tests",
 		Description: "Avoid paths containing test",
-		Path:        MustCompile(`\/test`),
+		Path:        MustCompile(`(\/test|-test|_test|\.test)`),
 	},
 	{
 		ID:          "vendor",

--- a/secret/scanner_test.go
+++ b/secret/scanner_test.go
@@ -182,13 +182,19 @@ func TestSecretScanner(t *testing.T) {
 			want:          types.Secret{},
 		},
 		{
-			name:          "allow-rule regex",
+			name:          "allow-rule regex inside group",
 			configPath:    "testdata/allow-regex.yaml",
 			inputFilePath: "testdata/secret.txt",
 			want: types.Secret{
 				FilePath: "testdata/secret.txt",
 				Findings: []types.SecretFinding{wantFinding1},
 			},
+		},
+		{
+			name:          "allow-rule regex outside group",
+			configPath:    "testdata/allow-regex-outside-group.yaml",
+			inputFilePath: "testdata/secret.txt",
+			want:          types.Secret{},
 		},
 		{
 			name:          "exclude-block regexes",

--- a/secret/testdata/allow-regex-outside-group.yaml
+++ b/secret/testdata/allow-regex-outside-group.yaml
@@ -1,0 +1,10 @@
+rules:
+  - id: rule1
+    category: general
+    title: Generic Rule
+    severity: HIGH
+    regex: (?i)line secret(=|:).{0,5}['"](?P<secret>[0-9a-zA-Z\-_=]{8,64})['"]
+    secret-group-name: secret
+    allow-rules:
+      - description: skip line
+        regex: line


### PR DESCRIPTION
When using the secret-group-name feature, the match we check the allow-list-rules on is the secret-group itself.
This behavior is unexpected and causes more false positives.
Changed to match the whole regex match for allow-rules, not only the secret-group.