### PR TITLE
fix(secrets): AsymmetricPrivateKeys use only base64 characters

### DIFF
--- a/secret/builtin-rules.go
+++ b/secret/builtin-rules.go
@@ -149,7 +149,7 @@ var builtinRules = []Rule{
 		Category:        CategoryAsymmetricPrivateKey,
 		Title:           "Asymmetric Private Key",
 		Severity:        "HIGH",
-		Regex:           MustCompile(`(?i)-----\s*?BEGIN[ A-Z0-9_-]*?PRIVATE KEY( BLOCK)?\s*?-----(?P<secret>[\s\S]*?)----\s*?END[ A-Z0-9_-]*? PRIVATE KEY( BLOCK)?\s*?-----`),
+		Regex:           MustCompile(`(?i)-----\s*?BEGIN[ A-Z0-9_-]*?PRIVATE KEY( BLOCK)?\s*?-----(?P<secret>[A-Za-z0-9=+/\s]*?)-----\s*?END[ A-Z0-9_-]*? PRIVATE KEY( BLOCK)?\s*?-----`),
 		SecretGroupName: "secret",
 		Keywords:        []string{"-----"},
 	},


### PR DESCRIPTION
## Description
Asymmetric private key can be obtained from any function.
For example([phpseclib/Crypt/RSA.php](https://github.com/phpseclib/phpseclib/blob/2.0.32/phpseclib/Crypt/RSA.php#L881-L883)):
```
...
 return "-----BEGIN OPENSSH PRIVATE KEY-----\r\n" .
             chunk_split(base64_encode($key), 70) .
        "-----END OPENSSH PRIVATE KEY-----";
...
```
Only base64 characters (with `=`) should be used to avoid false positives.

## Related Issues
- aquasecurity/trivy/issues/2190